### PR TITLE
add support for ollama embeddings

### DIFF
--- a/src/embedding/mod.rs
+++ b/src/embedding/mod.rs
@@ -1,2 +1,3 @@
 pub mod embedder_trait;
+pub mod ollama;
 pub mod openai;

--- a/src/embedding/ollama/mod.rs
+++ b/src/embedding/ollama/mod.rs
@@ -1,0 +1,1 @@
+pub mod ollama_embedder;

--- a/src/embedding/ollama/ollama_embedder.rs
+++ b/src/embedding/ollama/ollama_embedder.rs
@@ -1,0 +1,97 @@
+#![allow(dead_code)]
+use std::error::Error;
+
+use crate::embedding::embedder_trait::Embedder;
+use async_trait::async_trait;
+use reqwest::{Client, Url};
+use serde::Deserialize;
+use serde_json::json;
+
+#[derive(Debug, Deserialize)]
+struct EmbeddingResponse {
+    embedding: Vec<f64>,
+}
+
+#[derive(Debug)]
+pub struct OllamaEmbedder {
+    pub(crate) model: String,
+    pub(crate) base_url: String,
+}
+
+impl OllamaEmbedder {
+    pub fn new<S: Into<String>>(model: S, base_url: S) -> Self {
+        OllamaEmbedder {
+            model: model.into(),
+            base_url: base_url.into(),
+        }
+    }
+
+    pub fn with_model<S: Into<String>>(mut self, model: S) -> Self {
+        self.model = model.into();
+        self
+    }
+
+    pub fn with_api_base<S: Into<String>>(mut self, base_url: S) -> Self {
+        self.base_url = base_url.into();
+        self
+    }
+}
+
+impl Default for OllamaEmbedder {
+    fn default() -> Self {
+        let model = String::from("nomic-embed-text");
+        let base_url = String::from("http://localhost:11434");
+        OllamaEmbedder::new(model, base_url)
+    }
+}
+
+#[async_trait]
+impl Embedder for OllamaEmbedder {
+    async fn embed_documents(&self, documents: &[String]) -> Result<Vec<Vec<f64>>, Box<dyn Error>> {
+        log::debug!("Embedding documents: {:?}", documents);
+        let client = Client::new();
+        let url = Url::parse(&format!("{}{}", self.base_url, "/api/embeddings"))?;
+
+        let mut embeddings = Vec::with_capacity(documents.len());
+
+        for doc in documents {
+            let res = client
+                .post(url.clone())
+                .json(&json!({
+                    "prompt": doc,
+                    "model": &self.model,
+                }))
+                .send()
+                .await?;
+            if res.status() != 200 {
+                return Err("Error from OLLAMA".into());
+            }
+            let data: EmbeddingResponse = res.json().await?;
+            embeddings.push(data.embedding);
+        }
+
+        Ok(embeddings)
+    }
+
+    async fn embed_query(&self, text: &str) -> Result<Vec<f64>, Box<dyn Error>> {
+        log::debug!("Embedding query: {:?}", text);
+        let client = Client::new();
+        let url = Url::parse(&format!("{}{}", self.base_url, "/api/embeddings"))?;
+
+        let res = client
+            .post(url)
+            .json(&json!({
+                "prompt": text,
+                "model": &self.model,
+            }))
+            .send()
+            .await?;
+
+        if res.status() != 200 {
+            log::error!("Error from OLLAMA: {}", &res.status());
+            return Err("Error from OLLAMA".into());
+        }
+        let data: EmbeddingResponse = res.json().await?;
+        Ok(data.embedding)
+    }
+}


### PR DESCRIPTION
This add support for ollama embedding based of https://js.langchain.com/docs/integrations/text_embedding/ollama.

Ollama doesn't yet support OpenAI compatibility for embeddings api so adding one that directly calls ollama apis. When the compatibility is supported we can think of removing this if we want.

Ref:
- https://github.com/ollama/ollama/issues/2416
- https://github.com/ollama/ollama/pull/2925

Since the ollama api doesn't support batch embedding apis, we manually loop and make a request in serial order and send it.
Ref:
- https://github.com/ollama/ollama/pull/2924

Usage:

```rust
let embedding = OllamaEmbedder::default();

let result = embedding
    .embed_documents(&vec!["hello".into(), "world".into()])
    .await
    .unwrap();
println!("{:?}", result);


let result = embedding
    .embed_query("What is the captial of France?")
    .await
    .unwrap();
println!("{:?}", result);
```

