### PR TITLE
add support for surrealdb as vector store

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,11 +29,12 @@ sqlx = { version = "0.7.3", features = ["postgres", "runtime-tokio-native-tls", 
 uuid = {version = "1.7.0", features = ["v4"], optional = true }
 pgvector = {version = "0.3.2", features = ["postgres", "sqlx"], optional = true }
 text-splitter = { version = "0.7", features = ["tiktoken-rs","markdown"] }
-
+surrealdb = { version = "1.2.2", optional = true, default-features = false }
 
 [features]
 default = []
 postgres = ["pgvector", "sqlx", "uuid"]
+surrealdb = ["dep:surrealdb"]
 
 [dev-dependencies]
 tokio-test = "0.4.0"

--- a/src/vectorstore/mod.rs
+++ b/src/vectorstore/mod.rs
@@ -3,6 +3,9 @@ mod options;
 #[cfg(feature = "postgres")]
 pub mod pgvector;
 
+#[cfg(feature = "surrealdb")]
+pub mod surrealdb;
+
 mod vectorstore;
 pub use options::*;
 pub use vectorstore::*;

--- a/src/vectorstore/surrealdb/builder.rs
+++ b/src/vectorstore/surrealdb/builder.rs
@@ -1,0 +1,124 @@
+use std::{error::Error, sync::Arc};
+
+use surrealdb::{Connection, Surreal};
+
+use crate::embedding::embedder_trait::Embedder;
+
+use super::Store;
+
+pub struct StoreBuilder<C: Connection> {
+    db: Option<Surreal<C>>,
+    collection_name: String,
+    collection_table_name: Option<String>,
+    collection_metadata_key_name: Option<String>,
+    vector_dimensions: i32,
+    embedder: Option<Arc<dyn Embedder>>,
+    schemafull: bool,
+}
+
+impl<C: Connection> StoreBuilder<C> {
+    /// Create a new StoreBuilder optimized for SurrealDB. Refer to `new_with_compatiblity()` if
+    /// you are looking to connect to store created by python version of langchain.
+    /// * table is singular - "document" instead of "documents"
+    /// * uses single table instead of multiple tables
+    /// * creates a schemafull table required for faster indexing. https://github.com/surrealdb/surrealdb/issues/2013
+    pub fn new() -> Self {
+        StoreBuilder {
+            db: None,
+            collection_name: "document".to_string(),
+            collection_table_name: Some("document".to_string()),
+            collection_metadata_key_name: Some("collection".to_string()),
+            vector_dimensions: 0,
+            embedder: None,
+            schemafull: true,
+        }
+    }
+
+    /// Create a new StoreBuilder with compatibility with python version of langchain
+    pub fn new_with_compatiblity() -> Self {
+        StoreBuilder {
+            db: None,
+            collection_name: "documents".to_string(),
+            collection_table_name: None,
+            collection_metadata_key_name: None,
+            vector_dimensions: 0,
+            embedder: None,
+            schemafull: false,
+        }
+    }
+
+    /// Use surrealdb
+    /// ```no_run
+    /// let surrealdb_config = surrealdb::opt::Config::new()
+    ///     .set_strict(true)
+    ///     .capabilities(Capabilities::all())
+    ///     .user(surrealdb::opt::auth::Root {
+    ///         username: "username".into(),
+    ///         password: "password".into()
+    ///     });
+    /// let db = surrealdb::engine::any::connect(("ws://127.0.0.1:8000", surrealdb_config)).await?;
+    /// let store = StoreBuilder::new().db(db).vector_dimensions(1000).build()?;
+    /// store.initialize().await?;
+    /// ```
+    pub fn db(mut self, db: Surreal<C>) -> Self {
+        self.db = Some(db);
+        self
+    }
+
+    pub fn collection_name(mut self, collection_name: &str) -> Self {
+        self.collection_name = collection_name.into();
+        self
+    }
+
+    /// Setting collection_table_name to None, creates table per collection. Set to some value if
+    /// you would like to reuse table. Resuing table is not compatible with python version of
+    /// langchain.
+    pub fn collection_table_name(mut self, collection_table_name: Option<String>) -> Self {
+        self.collection_table_name = collection_table_name;
+        self
+    }
+
+    pub fn collection_metadata_key_name(
+        mut self,
+        collection_metadata_key_name: Option<String>,
+    ) -> Self {
+        self.collection_metadata_key_name = collection_metadata_key_name;
+        self
+    }
+
+    pub fn vector_dimensions(mut self, vector_dimensions: i32) -> Self {
+        self.vector_dimensions = vector_dimensions;
+        self
+    }
+
+    pub fn schemafull(mut self, schemafull: bool) -> Self {
+        self.schemafull = schemafull;
+        self
+    }
+
+    pub fn embedder<E: Embedder + 'static>(mut self, embedder: E) -> Self {
+        self.embedder = Some(Arc::new(embedder));
+        self
+    }
+
+    // Finalize the builder and construct the Store object
+    pub async fn build(self) -> Result<Store<C>, Box<dyn Error>> {
+        if self.embedder.is_none() {
+            return Err("Embedder is required".into());
+        }
+
+        if self.db.is_none() {
+            return Err("Db is required".into());
+        }
+
+        Ok(Store {
+            db: self.db.unwrap(),
+            collection_name: self.collection_name,
+            collection_table_name: self.collection_table_name,
+            collection_metadata_key_name: self.collection_metadata_key_name,
+            vector_dimensions: self.vector_dimensions,
+            embedder: self.embedder.unwrap(),
+            schemafull: self.schemafull,
+        })
+    }
+}

--- a/src/vectorstore/surrealdb/mod.rs
+++ b/src/vectorstore/surrealdb/mod.rs
@@ -1,0 +1,5 @@
+mod builder;
+mod surrealdb;
+
+pub use builder::*;
+pub use surrealdb::*;

--- a/src/vectorstore/surrealdb/surrealdb.rs
+++ b/src/vectorstore/surrealdb/surrealdb.rs
@@ -1,0 +1,224 @@
+use std::{collections::HashMap, error::Error, sync::Arc};
+
+use async_trait::async_trait;
+use serde::Deserialize;
+use serde_json::Value;
+use surrealdb::{Connection, Surreal};
+
+use crate::{
+    embedding::embedder_trait::Embedder,
+    schemas::Document,
+    vectorstore::{VecStoreOptions, VectorStore},
+};
+
+// INSERT INTO documents {
+//  text: 'some text,
+//  embedding: [1.0, 2.0, 3.0],
+//  metadata?: {},
+//  collection?: 'collection_name'
+// }
+
+pub struct Store<C: Connection> {
+    pub(crate) db: Surreal<C>,
+    pub(crate) collection_name: String,
+    pub(crate) collection_table_name: Option<String>,
+    pub(crate) collection_metadata_key_name: Option<String>,
+    pub(crate) vector_dimensions: i32,
+    pub(crate) embedder: Arc<dyn Embedder>,
+    pub(crate) schemafull: bool,
+}
+
+impl<C: Connection> Store<C> {
+    fn get_collection_table_name(&self) -> &str {
+        match &self.collection_table_name {
+            Some(collection_table_name) => collection_table_name.as_str(),
+            None => self.collection_name.as_str(),
+        }
+    }
+
+    fn get_collection_metdata_key(&self) -> String {
+        self.collection_metadata_key_name
+            .clone()
+            .unwrap_or_else(|| "collection".to_string())
+    }
+
+    pub async fn initialize(&self) -> Result<(), Box<dyn Error>> {
+        self.create_collection_table_if_not_exists().await?;
+        Ok(())
+    }
+
+    async fn create_collection_table_if_not_exists(&self) -> Result<(), Box<dyn Error>> {
+        if !self.schemafull {
+            return Ok(());
+        }
+
+        let vector_dimensions = self.vector_dimensions;
+
+        match &self.collection_table_name {
+            Some(collection_table_name) => {
+                self.db
+                    .query(format!(
+                        r#"
+                            DEFINE TABLE {collection_table_name} SCHEMAFULL;
+                            DEFINE FIELD text                      ON {collection_table_name} TYPE string;
+                            DEFINE FIELD embedding                 ON {collection_table_name} TYPE array ASSERT (array::len($value) = {vector_dimensions}) || (array::len($value) = 0);
+                            DEFINE FIELD embedding.*               ON {collection_table_name} TYPE float;
+                            DEFINE FIELD metadata                  ON {collection_table_name} FLEXIBLE TYPE option<object>;"#
+                    ))
+                    .await?
+                    .check()?;
+            }
+            None => {
+                let collection_table_name = &self.collection_name;
+                dbg!(&collection_table_name);
+                self.db
+                    .query(format!(
+                        r#"
+                            DEFINE TABLE {collection_table_name} SCHEMAFULL;
+                            DEFINE FIELD text              ON {collection_table_name} TYPE string;
+                            DEFINE FIELD embedding         ON {collection_table_name} TYPE array ASSERT (array::len($value) = {vector_dimensions}) || (array::len($value) = 0);
+                            DEFINE FIELD embedding.*       ON {collection_table_name} TYPE float;
+                            DEFINE FIELD metadata          ON {collection_table_name} FLEXIBLE TYPE option<object>;"#
+                    ))
+                    .await?
+                    .check()?;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl<C: Connection> VectorStore for Store<C> {
+    async fn add_documents(
+        &self,
+        docs: &[Document],
+        opt: &VecStoreOptions,
+    ) -> Result<Vec<String>, Box<dyn Error>> {
+        let texts: Vec<String> = docs.iter().map(|d| d.page_content.clone()).collect();
+
+        let embedder = opt.embedder.as_ref().unwrap_or(&self.embedder);
+
+        let vectors = embedder.embed_documents(&texts).await?;
+        if vectors.len() != docs.len() {
+            return Err(Box::new(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                "Number of vectors and documents do not match",
+            )));
+        }
+
+        let mut ids = Vec::with_capacity(docs.len());
+
+        for (doc, vector) in docs.iter().zip(vectors.iter()) {
+            match &self.collection_table_name {
+                Some(collection_table_name) => {
+                    let mut metadata: HashMap<String, Value> = doc.metadata.clone();
+                    metadata.insert(
+                        self.get_collection_metdata_key(),
+                        Value::String(self.collection_name.to_owned()),
+                    );
+
+                    let mut result = self
+                        .db
+                        .query(format!(
+                            r#"CREATE {collection_table_name} CONTENT {{
+                                text: $text,
+                                embedding: $embedding,
+                                metadata: $metadata,
+                            }}
+                            RETURN meta::id(id) as id"#
+                        ))
+                        .bind(("text", &doc.page_content))
+                        .bind(("embedding", &vector))
+                        .bind(("metadata", &metadata))
+                        .await?
+                        .check()?;
+
+                    let id: Option<String> = result.take("id")?;
+                    ids.push(id.unwrap());
+                }
+                None => {
+                    let collection_table_name = &self.collection_name;
+                    let mut result = self
+                        .db
+                        .query(format!(
+                            r#"CREATE {collection_table_name} CONTENT {{
+                                text: $text,
+                                embedding: $embedding,
+                                metadata: $metadata,
+                            }}
+                            RETURN meta::id(id) as id"#
+                        ))
+                        .bind(("text", &doc.page_content))
+                        .bind(("embedding", &vector))
+                        .bind(("metadata", &doc.metadata))
+                        .await?
+                        .check()?;
+
+                    let id: Option<String> = result.take("id")?;
+                    ids.push(id.unwrap());
+                }
+            }
+        }
+
+        Ok(ids)
+    }
+
+    async fn similarity_search(
+        &self,
+        query: &str,
+        limit: usize,
+        opt: &VecStoreOptions,
+    ) -> Result<Vec<Document>, Box<dyn Error>> {
+        let collection_name = &self.collection_name;
+        let collection_table_name = self.get_collection_table_name();
+
+        let query_vector = self.embedder.embed_query(query).await?;
+
+        let collection_predicate = match &self.collection_table_name {
+            Some(_) => " AND metadata[$collection_metadata_key] = $collection_name ",
+            None => "",
+        };
+
+        let mut result = self
+            .db
+            .query(format!(
+                r#"
+        SELECT meta::id(id) as id, text, metadata,
+        vector::similarity::cosine(embedding, $embedding) as similarity
+        FROM {collection_table_name}
+        WHERE vector::similarity::cosine(embedding, $embedding) >= $score_threshold {collection_predicate}
+        ORDER BY similarity DESC LIMIT $k
+            "#
+            ))
+            .bind(("collection_name", &collection_name))
+            .bind(("collection_metadata_key", &self.get_collection_metdata_key()))
+            .bind(("score_threshold", opt.score_threshold.unwrap_or(0.0)))
+            .bind(("k", limit))
+            .bind(("embedding", &query_vector))
+            .await?
+            .check()?;
+
+        let query_result: Vec<Row> = result.take(0)?;
+
+        let documents = query_result
+            .into_iter()
+            .map(|row| Document {
+                page_content: row.text,
+                metadata: row.metadata,
+                score: row.similarity,
+            })
+            .collect();
+
+        Ok(documents)
+    }
+}
+
+#[derive(Deserialize, Debug)]
+struct Row {
+    id: String,
+    text: String,
+    metadata: HashMap<String, Value>,
+    similarity: f64,
+}


### PR DESCRIPTION
Surrealdb is written in rust and can be used as a in memory db, embedded into the binary similar to sqlite with rocksdb/surrealkv or distributed with foundation db or tikv. This should open up langchain-rust for interesting scenarios.

- [x] Add initial support for SurrealDB
- [x] Add surrealdb under feature flag 
- [x] Add `initialize()` function in Store instead of `Builder` allow devs to optimize. 
- [x] use cosine similarity search similar to python implementation 
- [x] Verify compatibility with python langchain library implementation of surrealdb tables and columns
- [x] support compatibility mode in similarity_search

Example usage:

```toml
langchain-rust = { version = "2.3.0", features = ["surrealdb"] }
tokio = { version = "1.36.0", features = ["full"] }
surrealdb = { version = "1.2.2", features = [ "kv-mem", "kv-rocksdb", "kv-tikv" ] } # choose the backend that you wish.
```

Start surrealdb in the cli. Ignore this if using memory or rocksdb directly in rust code.

```
surreal start --allow-all --strict --bind=127.0.0.1:8000 --username=root --password=root file://./embeddings.db
```

<details>

<summary> rust code</summary>

```rust
use std::collections::HashMap;

use anyhow::Result;
use langchain_rust::{
    embedding::ollama::ollama_embedder::OllamaEmbedder,
    schemas::Document,
    vectorstore::{surrealdb::StoreBuilder, VecStoreOptions, VectorStore},
};

// surreal start --allow-all --strict --bind=127.0.0.1:8000 --username=root --password=root file://./embeddings.db

#[tokio::main]
async fn main() -> Result<()> {
    let embedder = OllamaEmbedder::default();

    let surrealdb_config = surrealdb::opt::Config::new()
        .set_strict(true)
        .capabilities(surrealdb::dbs::Capabilities::all())
        .user(surrealdb::opt::auth::Root {
            username: "root".into(),
            password: "root".into(),
        });
    let db = surrealdb::engine::any::connect(("ws://127.0.0.1:8000", surrealdb_config)).await?;
    db.query("DEFINE NAMESPACE test;").await?.check()?;
    db.query("USE NAMESPACE test; DEFINE DATABASE test;")
        .await?
        .check()?;

    db.use_ns("test").await?;
    db.use_db("test").await?;

    // db.query("REMOVE TABLE document;").await?.check()?;

    let store = StoreBuilder::new()
        .embedder(embedder)
        .db(db)
        .collection_name("docs")
        .vector_dimensions(768)
        .build()
        .await
        .unwrap();

    store.initialize().await.unwrap();

    let document_langchain_rust = Document {
        page_content: "langchain-rust is a port of the langchain python library to rust and was written in 2024.".to_string(),
        metadata: HashMap::new(),
        score: 0.0,
    };

    let document_langchain_go = Document {
        page_content:
            "langchaingo is a port of the langchain python library to go language and was written in 2023."
                .to_string(),
        metadata: HashMap::new(),
        score: 0.0,
    };
    let document_capital_of_france = Document {
        page_content: "Capital of France is Paris.".to_string(),
        metadata: HashMap::new(),
        score: 0.0,
    };

    store
        .add_documents(
            &[
                document_langchain_rust,
                document_langchain_go,
                document_capital_of_france,
            ],
            &VecStoreOptions::default(),
        )
        .await
        .unwrap();

    let query = "When was langchain-rust written?";
    println!("{query}");

    let result = store
        .similarity_search(
            query,
            4,
            &VecStoreOptions::default().with_score_threshold(0.5),
        )
        .await
        .unwrap();

    dbg!(&result);

    Ok(())
}
```

</details>

Example response: 
```
When was langchain-rust written?
[src/main.rs:87] &result = [
    Document {
        page_content: "langchain-rust is a port of the langchain python library to rust and was written in 2024.",
        metadata: {},
        score: 0.8335600508456985,
    },
    Document {
        page_content: "langchaingo is a port of the langchain python library to go language and was written in 2023.",
        metadata: {},
        score: 0.617680739695791,
    },
]
```

Example response:

```
What is the capital of France?
[src/main.rs:87] &result = [
    Document {
        page_content: "Capital of France is Paris.",
        metadata: {},
        score: 0.8915965310275719,
    },
]
```