### PR TITLE
feat: Add document loaders module

### DIFF
--- a/src/document_loaders/document_loader.rs
+++ b/src/document_loaders/document_loader.rs
@@ -6,9 +6,9 @@ use crate::{schemas::Document, text_splitter::TextSplitter};
 
 #[async_trait]
 pub trait Loader: Send + Sync {
-    async fn load(&mut self) -> Result<Vec<Document>, Box<dyn Error>>;
+    async fn load(mut self) -> Result<Vec<Document>, Box<dyn Error>>;
     async fn load_and_split<TS: TextSplitter + 'static>(
-        &mut self,
+        mut self,
         splitter: TS,
     ) -> Result<Vec<Document>, Box<dyn Error>>;
 }

--- a/src/document_loaders/document_loader.rs
+++ b/src/document_loaders/document_loader.rs
@@ -1,0 +1,14 @@
+use std::error::Error;
+
+use async_trait::async_trait;
+
+use crate::{schemas::Document, text_splitter::TextSplitter};
+
+#[async_trait]
+pub trait Loader: Send + Sync {
+    async fn load(&mut self) -> Result<Vec<Document>, Box<dyn Error>>;
+    async fn load_and_split<TS: TextSplitter + 'static>(
+        &mut self,
+        splitter: TS,
+    ) -> Result<Vec<Document>, Box<dyn Error>>;
+}

--- a/src/document_loaders/mod.rs
+++ b/src/document_loaders/mod.rs
@@ -1,0 +1,5 @@
+mod document_loader;
+pub use document_loader::*;
+
+mod text_loader;
+pub use text_loader::*;

--- a/src/document_loaders/text_loader/mod.rs
+++ b/src/document_loaders/text_loader/mod.rs
@@ -1,0 +1,2 @@
+mod text_loader;
+pub use text_loader::*;

--- a/src/document_loaders/text_loader/text_loader.rs
+++ b/src/document_loaders/text_loader/text_loader.rs
@@ -1,0 +1,63 @@
+use std::error::Error;
+
+use async_trait::async_trait;
+use tokio::io::{AsyncRead, AsyncReadExt, BufReader};
+
+use crate::{document_loaders::Loader, schemas::Document};
+
+pub struct TextLoader<R: AsyncRead> {
+    pub(crate) reader: R,
+}
+
+impl<R: AsyncRead> TextLoader<R> {
+    pub fn new(reader: R) -> Self {
+        Self { reader }
+    }
+}
+
+#[async_trait]
+impl<R: AsyncRead + Unpin + Send + Sync> Loader for TextLoader<R> {
+    async fn load(&mut self) -> Result<Vec<Document>, Box<dyn Error>> {
+        let mut reader = BufReader::new(&mut self.reader);
+        let mut buffer = Vec::new();
+
+        reader.read_to_end(&mut buffer).await?;
+
+        let buffer_string = std::str::from_utf8(&buffer)?.to_owned();
+
+        Ok(vec![Document::new(buffer_string)])
+    }
+
+    async fn load_and_split<TS: crate::text_splitter::TextSplitter + 'static>(
+        &mut self,
+        splitter: TS,
+    ) -> Result<Vec<Document>, Box<dyn Error>> {
+        let documents = self.load().await?;
+        let result = splitter.split_documents(&documents)?;
+        Ok(result)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Cursor;
+
+    #[tokio::test]
+    async fn test_load() {
+        let data = b"Hello, world!";
+        let reader = Cursor::new(data as &[u8]);
+        let mut loader = crate::document_loaders::TextLoader { reader };
+
+        let result = crate::document_loaders::Loader::load(&mut loader).await;
+
+        match result {
+            Ok(docs) => {
+                assert_eq!(docs.len(), 1);
+                assert_eq!(docs[0].page_content, "Hello, world!");
+            }
+            Err(e) => {
+                panic!("Error during loading: {}", e);
+            }
+        }
+    }
+}

--- a/src/document_loaders/text_loader/text_loader.rs
+++ b/src/document_loaders/text_loader/text_loader.rs
@@ -4,6 +4,7 @@ use async_trait::async_trait;
 
 use crate::{document_loaders::Loader, schemas::Document, text_splitter::TextSplitter};
 
+#[derive(Debug, Clone)]
 pub struct TextLoader {
     content: String,
 }

--- a/src/document_loaders/text_loader/text_loader.rs
+++ b/src/document_loaders/text_loader/text_loader.rs
@@ -46,8 +46,6 @@ mod tests {
         // Use the loader to load the content, which should be wrapped in a Document
         let documents = loader.load().await.expect("Failed to load content");
 
-        // Assert that the documents contain the expected content
-        // This part depends on how your Document struct is defined and how you want to verify its content
         assert_eq!(documents.len(), 1); // Assuming the content should be wrapped in a single Document
         assert_eq!(documents[0].page_content, mocked_file_content); // Ensure the Document contains the mocked content
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 #![allow(dead_code)]
 pub mod agent;
 pub mod chain;
+pub mod document_loaders;
 pub mod embedding;
 pub mod language_models;
 pub mod llm;

--- a/src/text_splitter/text_splitter.rs
+++ b/src/text_splitter/text_splitter.rs
@@ -4,7 +4,7 @@ use serde_json::Value;
 
 use crate::schemas::Document;
 
-pub trait TextSplitter {
+pub trait TextSplitter: Send + Sync {
     fn split_text(&self, text: &str) -> Result<Vec<String>, Box<dyn Error>>;
 
     fn split_documents(&self, documents: &[Document]) -> Result<Vec<Document>, Box<dyn Error>> {


### PR DESCRIPTION
This commit introduces the document loaders module that includes two core components:

- The document_loader that provides the load and load_and_split functions with an asynchronous trait implementation.
- The text_loader that reads an AsyncRead resource and interfaces with the document_loader to load the documents.

The text_splitter trait has been adjusted to include sending and synchronization.

Refer to the individual files for a detailed implementation.

This update does not affect other parts of the system.