### PR TITLE
feat: Add streaming functionality to the language chain

### DIFF
--- a/examples/streaming_from_chain.rs
+++ b/examples/streaming_from_chain.rs
@@ -31,7 +31,7 @@ async fn main() {
 
     let mut stream = chain
         .stream(prompt_args! {
-        "input" => "Quien es el escritor de 20000 millas de viaje submarino",
+        "input" => "Who is the writer of 20,000 Leagues Under the Sea?",
            })
         .await
         .unwrap();

--- a/examples/streaming_from_chain.rs
+++ b/examples/streaming_from_chain.rs
@@ -1,0 +1,48 @@
+use futures::StreamExt;
+use langchain_rust::{
+    chain::{Chain, LLMChainBuilder},
+    fmt_message, fmt_template,
+    llm::openai::OpenAI,
+    message_formatter,
+    prompt::HumanMessagePromptTemplate,
+    prompt_args,
+    schemas::messages::Message,
+    template_fstring,
+};
+
+#[tokio::main]
+async fn main() {
+    let open_ai = OpenAI::default();
+
+    let prompt = message_formatter![
+        fmt_message!(Message::new_system_message(
+            "You are world class technical documentation writer."
+        )),
+        fmt_template!(HumanMessagePromptTemplate::new(template_fstring!(
+            "{input}", "input"
+        )))
+    ];
+
+    let chain = LLMChainBuilder::new()
+        .prompt(prompt)
+        .llm(open_ai.clone())
+        .build()
+        .unwrap();
+
+    let mut stream = chain
+        .stream(prompt_args! {
+        "input" => "Quien es el escritor de 20000 millas de viaje submarino",
+           })
+        .await
+        .unwrap();
+    while let Some(result) = stream.next().await {
+        match result {
+            Ok(value) => {
+                if let Some(content) = value.pointer("/choices/0/delta/content") {
+                    println!("Content: {}", content.as_str().unwrap_or(""));
+                }
+            }
+            Err(e) => panic!("Error invoking LLMChain: {:?}", e),
+        }
+    }
+}

--- a/src/chain/chain_trait.rs
+++ b/src/chain/chain_trait.rs
@@ -1,6 +1,7 @@
-use std::{collections::HashMap, error::Error};
+use std::{collections::HashMap, error::Error, pin::Pin};
 
 use async_trait::async_trait;
+use futures::Stream;
 use serde_json::{json, Value};
 
 use crate::{language_models::GenerateResult, prompt::PromptArgs};
@@ -34,6 +35,17 @@ pub trait Chain: Sync + Send {
         output.insert(output_key, json!(result.generation));
         output.insert(DEFAULT_RESULT_KEY.to_string(), json!(result));
         Ok(output)
+    }
+
+    async fn stream(
+        &self,
+        _input_variables: PromptArgs,
+    ) -> Result<
+        Pin<Box<dyn Stream<Item = Result<serde_json::Value, Box<dyn Error + Send>>> + Send>>,
+        Box<dyn Error>,
+    > {
+        log::warn!("stream not implemented for this chain");
+        unimplemented!()
     }
 
     // Get the input keys of the prompt

--- a/src/language_models/llm.rs
+++ b/src/language_models/llm.rs
@@ -1,6 +1,7 @@
-use std::error::Error;
+use std::{error::Error, pin::Pin};
 
 use async_trait::async_trait;
+use futures::Stream;
 
 use crate::schemas::messages::Message;
 
@@ -8,8 +9,18 @@ use super::{options::CallOptions, GenerateResult};
 
 #[async_trait]
 pub trait LLM: Sync + Send {
-    async fn generate(&self, messgaes: &[Message]) -> Result<GenerateResult, Box<dyn Error>>;
+    async fn generate(&self, messages: &[Message]) -> Result<GenerateResult, Box<dyn Error>>;
     async fn invoke(&self, prompt: &str) -> Result<String, Box<dyn Error>>;
+    async fn stream(
+        &self,
+        _messages: &[Message],
+    ) -> Result<
+        Pin<Box<dyn Stream<Item = Result<serde_json::Value, Box<dyn Error + Send>>> + Send>>,
+        Box<dyn Error>,
+    > {
+        log::warn!("stream not implemented for this model");
+        unimplemented!()
+    }
     fn with_options(&mut self, _options: CallOptions) {
         // No action taken
     }


### PR DESCRIPTION
This commit introduces a streaming functionality in the language chain. A new 'stream' function is added to the Chain trait that is expected to be implemented by all chains. A corresponding 'stream' implementation is provided in the LLMChain struct as well. The LLM trait has also been updated to include a 'stream' function. The 'stream' function is also implemented in the OpenAI struct, where the chat API is leveraged to create a stream of response generation.

In addition, a new example of usage of the streaming API has been included under the examples directory.