### PR TITLE
build tests but don't run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,11 @@ jobs:
         with:
           command: build
           args: --verbose --all --release --all-features
+      - name: Build Test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --no-run --release --all-features
 
   publish_crate:
     if: startsWith(github.ref, 'refs/tags/')


### PR DESCRIPTION
At some point we probably want to group the tests that requires LLM and that doesn't require so we can run the non LLM ones in the CI. For now build it but don't run any tests.