### PR TITLE
fix(llm_chain): fix memory

### DIFF
--- a/src/chain/llm_chain.rs
+++ b/src/chain/llm_chain.rs
@@ -160,7 +160,6 @@ mod tests {
             result.is_ok(),
             "Error invoking LLMChain: {:?}",
             result.err()
-        );
+        )
     }
 }
-


### PR DESCRIPTION
I found an issue with the memrory manage in llm_chain to prevent errors I delete the memory from llm_chain

the error was it was only looking for an "input" if it was no input it will fail

also it was adding only the input to the memory, istead of the complete prompt

if someone want to use memory shoud use the conversational chain which was build to use memory.

evaluete if in the future we can suport memory in the llm_chian, maybe is better to leave the memory mangement to then chain using the llm_chain.