### PR TITLE
run tests in ci but ignore openai tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
           profile: minimal
           components: rustfmt, clippy
       - uses: swatinem/rust-cache@v2.7.3
-      - name: rust fmt
+      - name: Rust fmt
         uses: actions-rs/cargo@v1
         with:
           command: fmt
@@ -54,11 +54,11 @@ jobs:
         with:
           command: build
           args: --verbose --all --release --all-features
-      - name: Build Test
+      - name: Run Test
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --no-run --release --all-features
+          args: --release --all-features
 
   publish_crate:
     if: startsWith(github.ref, 'refs/tags/')

--- a/src/agent/chat/chat_agent.rs
+++ b/src/agent/chat/chat_agent.rs
@@ -141,6 +141,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore]
     async fn test_invoke_agent() {
         let llm = OpenAI::default().with_model(OpenAIModel::Gpt4.to_string());
         let memory = SimpleMemory::new();

--- a/src/chain/conversational/mod.rs
+++ b/src/chain/conversational/mod.rs
@@ -96,6 +96,7 @@ mod tests {
     use super::*;
 
     #[tokio::test]
+    #[ignore]
     async fn test_invoke_conversational() {
         let llm = OpenAI::default().with_model(OpenAIModel::Gpt35.to_string());
         let chain = ConversationalChainBuilder::new()

--- a/src/chain/question_answering.rs
+++ b/src/chain/question_answering.rs
@@ -52,6 +52,7 @@ mod tests {
     };
 
     #[tokio::test]
+    #[ignore]
     async fn test_qa() {
         let llm = OpenAI::default();
         let chain = load_stuff_qa(llm);

--- a/src/chain/sequential/chain.rs
+++ b/src/chain/sequential/chain.rs
@@ -97,6 +97,7 @@ mod tests {
     };
 
     #[tokio::test]
+    #[ignore]
     async fn test_sequential() {
         let llm = OpenAI::default();
         let chain1 = LLMChainBuilder::new()

--- a/src/vectorstore/surrealdb/builder.rs
+++ b/src/vectorstore/surrealdb/builder.rs
@@ -49,16 +49,21 @@ impl<C: Connection> StoreBuilder<C> {
 
     /// Use surrealdb
     /// ```no_run
-    /// let surrealdb_config = surrealdb::opt::Config::new()
-    ///     .set_strict(true)
-    ///     .capabilities(Capabilities::all())
-    ///     .user(surrealdb::opt::auth::Root {
-    ///         username: "username".into(),
-    ///         password: "password".into()
-    ///     });
-    /// let db = surrealdb::engine::any::connect(("ws://127.0.0.1:8000", surrealdb_config)).await?;
-    /// let store = StoreBuilder::new().db(db).vector_dimensions(1000).build()?;
-    /// store.initialize().await?;
+    /// use langchain_rust::vectorstore::surrealdb::StoreBuilder;
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let surrealdb_config = surrealdb::opt::Config::new()
+    ///         .set_strict(true)
+    ///         .capabilities(surrealdb::dbs::Capabilities::all())
+    ///         .user(surrealdb::opt::auth::Root {
+    ///             username: "username".into(),
+    ///             password: "password".into()
+    ///         });
+    ///     let db = surrealdb::engine::any::connect(("ws://127.0.0.1:8000", surrealdb_config)).await.unwrap();
+    ///     let store = StoreBuilder::new().db(db).vector_dimensions(1000).build().await.unwrap();
+    ///     store.initialize().await.unwrap();
+    /// }
     /// ```
     pub fn db(mut self, db: Surreal<C>) -> Self {
         self.db = Some(db);


### PR DESCRIPTION
This enabled running tests in CI. For those that require OpenAI or network requests it is suggested to add `#[ignore]` attribute. This will avoid running this tests when using `cargo test`. If you want to run all tests use `cargo test && cargo test -- --ignored`.

Probably worth investing in Mock Open AI at some point so we can potentially run all tests.