### PR TITLE
improve streaming_from_chain example to correctly stream the response

### DIFF
--- a/examples/streaming_from_chain.rs
+++ b/examples/streaming_from_chain.rs
@@ -1,3 +1,5 @@
+use std::io::{stdout, Write};
+
 use futures::StreamExt;
 use langchain_rust::{
     chain::{Chain, LLMChainBuilder},
@@ -35,11 +37,13 @@ async fn main() {
            })
         .await
         .unwrap();
+
     while let Some(result) = stream.next().await {
         match result {
             Ok(value) => {
                 if let Some(content) = value.pointer("/choices/0/delta/content") {
-                    println!("Content: {}", content.as_str().unwrap_or(""));
+                    print!("{}", content.as_str().unwrap_or(""));
+                    stdout().flush().unwrap();
                 }
             }
             Err(e) => panic!("Error invoking LLMChain: {:?}", e),


### PR DESCRIPTION
Update the `streaming_from_chain` to correctly stream the response in console.