### PR TITLE
refactor: Update tools used in ConversationalAgentBuilder and add Ser…

### DIFF
--- a/examples/agent.rs
+++ b/examples/agent.rs
@@ -3,38 +3,28 @@ use std::sync::Arc;
 use langchain_rust::{
     agent::{AgentExecutor, ChatOutputParser, ConversationalAgentBuilder},
     chain::{options::ChainCallOptions, Chain},
-    llm::openai::OpenAI,
+    llm::openai::{OpenAI, OpenAIModel},
     memory::SimpleMemory,
     prompt_args,
-    tools::Wolfram,
+    tools::SerpApi,
 };
 
 #[tokio::main]
 async fn main() {
-    let llm = OpenAI::default();
+    let llm = OpenAI::default().with_model(OpenAIModel::Gpt4Turbo);
     let memory = SimpleMemory::new();
-    let wolfram_tool = Wolfram::default();
+    let serpapi_tool = SerpApi::default();
     let agent = ConversationalAgentBuilder::new()
-        .tools(vec![Arc::new(wolfram_tool)])
+        .tools(vec![Arc::new(serpapi_tool)])
         .output_parser(ChatOutputParser::new().into())
         .options(ChainCallOptions::new().with_max_tokens(1000))
         .build(llm)
         .unwrap();
 
-    let input_variables = prompt_args! {
-        "input" => "Hello",
-    };
-
     let executor = AgentExecutor::from_agent(agent).with_memory(memory.into());
-    match executor.invoke(input_variables).await {
-        Ok(result) => {
-            println!("Result: {:?}", result);
-        }
-        Err(e) => panic!("Error invoking LLMChain: {:?}", e),
-    }
 
     let input_variables = prompt_args! {
-        "input" => "What is the area under the curve e^{-x^2}?",
+        "input" => "Who is Leonardo DiCaprio's girlfriend, and how old is she?",
     };
 
     match executor.invoke(input_variables).await {

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -1,9 +1,14 @@
-mod scraper;
-mod sql;
 mod tool;
+pub use tool::*;
+
+pub use wolfram::*;
 mod wolfram;
 
+mod scraper;
 pub use scraper::*;
+
+mod sql;
 pub use sql::*;
-pub use tool::*;
-pub use wolfram::*;
+
+mod serpapi;
+pub use serpapi::*;

--- a/src/tools/serpapi/mod.rs
+++ b/src/tools/serpapi/mod.rs
@@ -1,0 +1,2 @@
+mod serpapi;
+pub use serpapi::*;

--- a/src/tools/serpapi/serpapi.rs
+++ b/src/tools/serpapi/serpapi.rs
@@ -1,0 +1,189 @@
+use std::error::Error;
+
+use async_trait::async_trait;
+use serde_json::Value;
+
+use crate::tools::Tool;
+
+pub struct SerpApi {
+    api_key: String,
+    location: Option<String>,
+    hl: Option<String>,
+    gl: Option<String>,
+    google_domain: Option<String>,
+}
+
+impl SerpApi {
+    pub fn new(api_key: String) -> Self {
+        Self {
+            api_key,
+            location: None,
+            hl: None,
+            gl: None,
+            google_domain: None,
+        }
+    }
+    pub fn with_location(mut self, location: String) -> Self {
+        self.location = Some(location);
+        self
+    }
+    pub fn with_hl(mut self, hl: String) -> Self {
+        self.hl = Some(hl);
+        self
+    }
+    pub fn with_gl(mut self, gl: String) -> Self {
+        self.gl = Some(gl);
+        self
+    }
+    pub fn with_google_domain(mut self, google_domain: String) -> Self {
+        self.google_domain = Some(google_domain);
+        self
+    }
+    pub async fn simple_search(&self, query: &str) -> Result<String, Box<dyn Error>> {
+        let mut url = format!(
+            "https://serpapi.com/search.json?q={}&api_key={}",
+            query, self.api_key
+        );
+        if let Some(location) = &self.location {
+            url.push_str(&format!("&location={}", location));
+        }
+        if let Some(hl) = &self.hl {
+            url.push_str(&format!("&hl={}", hl));
+        }
+        if let Some(gl) = &self.gl {
+            url.push_str(&format!("&gl={}", gl));
+        }
+        if let Some(google_domain) = &self.google_domain {
+            url.push_str(&format!("&google_domain={}", google_domain));
+        }
+        let results: Value = reqwest::get(&url).await?.json().await?;
+
+        let res = process_response(&results)?;
+
+        Ok(res)
+    }
+}
+
+fn get_answer_box(result: &Value) -> String {
+    if let Some(map) = result["answer_box"].as_object() {
+        if let Some(answer) = map.get("answer").and_then(|v| v.as_str()) {
+            return answer.to_string();
+        }
+
+        if let Some(snippet) = map.get("snippet").and_then(|v| v.as_str()) {
+            return snippet.to_string();
+        }
+
+        if let Some(snippet) = map
+            .get("snippet_highlighted_words")
+            .and_then(|v| v.as_array())
+        {
+            if !snippet.is_empty() {
+                if let Some(first) = snippet.first().and_then(|v| v.as_str()) {
+                    return first.to_string();
+                }
+            }
+        }
+    }
+
+    "".to_string()
+}
+
+fn process_response(res: &Value) -> Result<String, Box<dyn Error>> {
+    if !get_answer_box(res).is_empty() {
+        return Ok(get_answer_box(res));
+    }
+    if !get_sport_result(res).is_empty() {
+        return Ok(get_sport_result(res));
+    }
+    if !get_knowledge_graph(res).is_empty() {
+        return Ok(get_knowledge_graph(res));
+    }
+    if !get_organic_result(res).is_empty() {
+        return Ok(get_organic_result(res));
+    }
+    Err("No good result".into())
+}
+
+fn get_sport_result(result: &Value) -> String {
+    if let Some(map) = result["sports_results"].as_object() {
+        if let Some(game_spotlight) = map.get("game_spotlight").and_then(|v| v.as_str()) {
+            return game_spotlight.to_string();
+        }
+    }
+
+    "".to_string()
+}
+
+fn get_knowledge_graph(result: &Value) -> String {
+    if let Some(map) = result["knowledge_graph"].as_object() {
+        if let Some(description) = map.get("description").and_then(|v| v.as_str()) {
+            return description.to_string();
+        }
+    }
+
+    "".to_string()
+}
+
+fn get_organic_result(result: &Value) -> String {
+    if let Some(array) = result["organic_results"].as_array() {
+        if !array.is_empty() {
+            if let Some(first) = array.first() {
+                if let Some(first_map) = first.as_object() {
+                    if let Some(snippet) = first_map.get("snippet").and_then(|v| v.as_str()) {
+                        return snippet.to_string();
+                    }
+                }
+            }
+        }
+    }
+
+    "".to_string()
+}
+
+#[async_trait]
+impl Tool for SerpApi {
+    fn name(&self) -> String {
+        String::from("GoogleSearch")
+    }
+    fn description(&self) -> String {
+        String::from(
+            r#""A wrapper around Google Search. "
+	"Useful for when you need to answer questions about current events. "
+	"Always one of the first options when you need to find information on internet"
+	"Input should be a search query."#,
+        )
+    }
+
+    async fn call(&self, input: &str) -> Result<String, Box<dyn Error>> {
+        self.simple_search(input).await
+    }
+}
+
+impl Default for SerpApi {
+    fn default() -> SerpApi {
+        SerpApi {
+            api_key: std::env::var("SERPAPI_API_KEY").unwrap_or_default(),
+            location: None,
+            hl: None,
+            gl: None,
+            google_domain: None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::SerpApi;
+
+    #[tokio::test]
+    #[ignore]
+    async fn serpapi_tool() {
+        let serpapi = SerpApi::default();
+        let s = serpapi
+            .simple_search("Cual es el ultimo iphone?")
+            .await
+            .unwrap();
+        println!("{}", s);
+    }
+}


### PR DESCRIPTION
…pApi tool

- Updated the tools used in the ConversationalAgentBuilder in agent.rs to include the SerpApi tool instead of the Wolfram tool.
- Added a new module for the SerpApi tool in the tools directory.
- Created the SerpApi struct with methods for configuring the API key, location, language, and Google domain.
- Implemented the simple_search method for performing a search using the SerpApi tool.
- Implemented the Tool trait for the SerpApi tool with the name, description, and call methods.
- Added a test for the SerpApi tool in the tests module.

This commit enhances the functionality of the ConversationalAgentBuilder by adding the SerpApi tool for conducting internet searches.