### PR TITLE
Add support for sqlite_vss as vector store

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ reqwest-eventsource = "0.5.0"
 async-openai = "0.19.1"
 mockito = "1.4.0"
 tiktoken-rs = "0.5.8"
-sqlx = { version = "0.7.4", features = ["postgres", "runtime-tokio-native-tls", "json", "uuid" ], optional = true }
+sqlx = { version = "0.7.4", default-features = false, features = ["postgres", "sqlite", "runtime-tokio-native-tls", "json", "uuid" ], optional = true }
 uuid = {version = "1.8.0", features = ["v4"], optional = true }
 pgvector = {version = "0.3.2", features = ["postgres", "sqlx"], optional = true }
 text-splitter = { version = "0.7", features = ["tiktoken-rs","markdown"] }
@@ -41,6 +41,7 @@ async-stream = "0.3.5"
 default = []
 postgres = ["pgvector", "sqlx", "uuid"]
 surrealdb = ["dep:surrealdb"]
+sqlite = ["sqlx"]
 
 [dev-dependencies]
 tokio-test = "0.4.4"

--- a/README.md
+++ b/README.md
@@ -55,6 +55,13 @@ Then, you can add `langchain-rust` to your Rust project.
 ```bash
 cargo add langchain-rust
 ```
+#### With Sqlite
+
+```bash
+cargo add langchain-rust --features sqlite
+```
+
+Download additional sqlite_vss libraries from https://github.com/asg017/sqlite-vss
 
 #### With Postgres
 
@@ -68,13 +75,13 @@ cargo add langchain-rust --features postgres
 cargo add langchain-rust --features surrealdb
 ```
 
-Please remember to replace the feature flags `postgres` or `surrealdb` based on your
+Please remember to replace the feature flags `sqlite`, `postgres` or `surrealdb` based on your
 specific use case.
 
 This will add both `serde_json` and `langchain-rust` as dependencies in your `Cargo.toml`
 file. Now, when you build your project, both dependencies will be fetched and compiled, and will be available for use in your project.
 
-Remember, `serde_json` is a necessary dependencies, and `postgres` and `surrealdb`
+Remember, `serde_json` is a necessary dependencies, and `sqlite`, `postgres` and `surrealdb`
 are optional features that may be added according to project needs.
 
 ### Quick Start Conversational Chain

--- a/examples/vector_store_postgres.rs
+++ b/examples/vector_store_postgres.rs
@@ -1,4 +1,4 @@
-// To run this example execute: cargo run --example vector_stores --features postgres
+// To run this example execute: cargo run --example vector_store_postgres --features postgres
 
 #[cfg(feature = "postgres")]
 use langchain_rust::{
@@ -72,5 +72,5 @@ async fn main() {
 fn main() {
     println!("This example requires the 'postgres' feature to be enabled.");
     println!("Please run the command as follows:");
-    println!("cargo run --example vector_stores --features postgres");
+    println!("cargo run --example vector_store_postgres --features postgres");
 }

--- a/examples/vector_store_sqlite.rs
+++ b/examples/vector_store_sqlite.rs
@@ -1,0 +1,80 @@
+// To run this example execute: cargo run --example vector_store_sqlite --features sqlite
+// Make sure vector0 and vss0 libraries are installed in the system or the path of the executable.
+// Download the libraries from https://github.com/asg017/sqlite-vss
+// For static compliation of sqlite-vss extension refer to the following link:
+// https://github.com/launchbadge/sqlx/issues/3147.
+
+#[cfg(feature = "sqlite")]
+use langchain_rust::{
+    embedding::openai::openai_embedder::OpenAiEmbedder,
+    schemas::Document,
+    vectorstore::{sqlite_vss::StoreBuilder, VecStoreOptions, VectorStore},
+};
+#[cfg(feature = "sqlite")]
+use std::io::Write;
+
+#[cfg(feature = "sqlite")]
+#[tokio::main]
+async fn main() {
+    // Initialize Embedder
+    let embedder = OpenAiEmbedder::default();
+
+    let database_url = std::env::var("DATABASE_URL").unwrap_or("sqlite::memory:".to_string());
+
+    // Initialize the Sqlite Vector Store
+    let store = StoreBuilder::new()
+        .embedder(embedder)
+        .connection_url(database_url)
+        .table("documents")
+        .vector_dimensions(1536)
+        .build()
+        .await
+        .unwrap();
+
+    // Intialize the tables in the database. This is required to be done only once.
+    store.initialize().await.unwrap();
+
+    // Add documents to the database
+    let doc1 = Document::new(
+        "langchain-rust is a port of the langchain python library to rust and was written in 2024.",
+    );
+    let doc2 = Document::new(
+        "langchaingo is a port of the langchain python library to go language and was written in 2023."
+    );
+    let doc3 = Document::new(
+        "Capital of United States of America (USA) is Washington D.C. and the capital of France is Paris."
+    );
+    let doc4 = Document::new("Capital of France is Paris.");
+
+    store
+        .add_documents(&vec![doc1, doc2, doc3, doc4], &VecStoreOptions::default())
+        .await
+        .unwrap();
+
+    // Ask for user input
+    print!("Query> ");
+    std::io::stdout().flush().unwrap();
+    let mut query = String::new();
+    std::io::stdin().read_line(&mut query).unwrap();
+
+    let results = store
+        .similarity_search(&query, 2, &VecStoreOptions::default())
+        .await
+        .unwrap();
+
+    if results.is_empty() {
+        println!("No results found.");
+        return;
+    } else {
+        results.iter().for_each(|r| {
+            println!("Document: {}", r.page_content);
+        });
+    }
+}
+
+#[cfg(not(feature = "sqlite"))]
+fn main() {
+    println!("This example requires the 'sqlite' feature to be enabled.");
+    println!("Please run the command as follows:");
+    println!("cargo run --example vector_store_sqlite --features sqlite");
+}

--- a/src/vectorstore/mod.rs
+++ b/src/vectorstore/mod.rs
@@ -3,6 +3,9 @@ mod options;
 #[cfg(feature = "postgres")]
 pub mod pgvector;
 
+#[cfg(feature = "sqlite")]
+pub mod sqlite_vss;
+
 #[cfg(feature = "surrealdb")]
 pub mod surrealdb;
 

--- a/src/vectorstore/sqlite_vss/builder.rs
+++ b/src/vectorstore/sqlite_vss/builder.rs
@@ -1,0 +1,93 @@
+use std::{error::Error, str::FromStr, sync::Arc};
+
+use sqlx::{
+    sqlite::{SqliteConnectOptions, SqlitePoolOptions},
+    Pool, Sqlite,
+};
+
+use super::Store;
+use crate::embedding::embedder_trait::Embedder;
+
+pub struct StoreBuilder {
+    pool: Option<Pool<Sqlite>>,
+    connection_url: Option<String>,
+    table: String,
+    vector_dimensions: i32,
+    embedder: Option<Arc<dyn Embedder>>,
+}
+
+impl StoreBuilder {
+    pub fn new() -> Self {
+        StoreBuilder {
+            pool: None,
+            connection_url: None,
+            table: "documents".to_string(),
+            vector_dimensions: 0,
+            embedder: None,
+        }
+    }
+
+    pub fn pool(mut self, pool: Pool<Sqlite>) -> Self {
+        self.pool = Some(pool);
+        self.connection_url = None;
+        self
+    }
+
+    pub fn connection_url<S: Into<String>>(mut self, connection_url: S) -> Self {
+        self.connection_url = Some(connection_url.into());
+        self.pool = None;
+        self
+    }
+
+    pub fn table(mut self, table: &str) -> Self {
+        self.table = table.into();
+        self
+    }
+
+    pub fn vector_dimensions(mut self, vector_dimensions: i32) -> Self {
+        self.vector_dimensions = vector_dimensions;
+        self
+    }
+
+    pub fn embedder<E: Embedder + 'static>(mut self, embedder: E) -> Self {
+        self.embedder = Some(Arc::new(embedder));
+        self
+    }
+
+    // Finalize the builder and construct the Store object
+    pub async fn build(self) -> Result<Store, Box<dyn Error>> {
+        if self.embedder.is_none() {
+            return Err("Embedder is required".into());
+        }
+
+        Ok(Store {
+            pool: self.get_pool().await?,
+            table: self.table,
+            vector_dimensions: self.vector_dimensions,
+            embedder: self.embedder.unwrap(),
+        })
+    }
+
+    async fn get_pool(&self) -> Result<Pool<Sqlite>, Box<dyn Error>> {
+        match &self.pool {
+            Some(pool) => Ok(pool.clone()),
+            None => {
+                let connection_url = self
+                    .connection_url
+                    .as_ref()
+                    .ok_or("Connection URL or DB is required")?;
+
+                let pool: Pool<Sqlite> = SqlitePoolOptions::new()
+                    .connect_with(
+                        SqliteConnectOptions::from_str(connection_url)?
+                            .create_if_missing(true)
+                            .extension("vector0")
+                            .extension("vss0"),
+                    )
+                    .await?;
+
+                Ok(pool)
+            }
+        }
+    }
+}

--- a/src/vectorstore/sqlite_vss/mod.rs
+++ b/src/vectorstore/sqlite_vss/mod.rs
@@ -1,0 +1,5 @@
+mod builder;
+mod sqlite_vss;
+
+pub use builder::*;
+pub use sqlite_vss::*;

--- a/src/vectorstore/sqlite_vss/sqlite_vss.rs
+++ b/src/vectorstore/sqlite_vss/sqlite_vss.rs
@@ -1,0 +1,174 @@
+use std::{collections::HashMap, error::Error, sync::Arc};
+
+use async_trait::async_trait;
+use serde_json::{json, Value};
+use sqlx::{Pool, Row, Sqlite};
+
+use crate::{
+    embedding::embedder_trait::Embedder,
+    schemas::Document,
+    vectorstore::{VecStoreOptions, VectorStore},
+};
+
+pub struct Store {
+    pub(crate) pool: Pool<Sqlite>,
+    pub(crate) table: String,
+    pub(crate) vector_dimensions: i32,
+    pub(crate) embedder: Arc<dyn Embedder>,
+}
+
+impl Store {
+    pub async fn initialize(&self) -> Result<(), Box<dyn Error>> {
+        self.create_table_if_not_exists().await?;
+        Ok(())
+    }
+
+    async fn create_table_if_not_exists(&self) -> Result<(), Box<dyn Error>> {
+        let table = &self.table;
+
+        sqlx::query(&format!(
+            r#"
+                CREATE TABLE IF NOT EXISTS {table}
+                (
+                  rowid INTEGER PRIMARY KEY AUTOINCREMENT,
+                  text TEXT,
+                  metadata BLOB,
+                  text_embedding BLOB
+                )
+                ;
+                "#
+        ))
+        .execute(&self.pool)
+        .await?;
+
+        let dimensions = self.vector_dimensions;
+        sqlx::query(&format!(
+            r#"
+                CREATE VIRTUAL TABLE IF NOT EXISTS vss_{table} USING vss0(
+                  text_embedding({dimensions})
+                );
+                "#
+        ))
+        .execute(&self.pool)
+        .await?;
+
+        // NOTE: python langchain seems to only use "embed_text" as the trigger name
+        sqlx::query(&format!(
+            r#"
+                CREATE TRIGGER IF NOT EXISTS embed_text_{table}
+                AFTER INSERT ON {table}
+                BEGIN
+                    INSERT INTO vss_{table}(rowid, text_embedding)
+                    VALUES (new.rowid, new.text_embedding)
+                    ;
+                END;
+                "#
+        ))
+        .execute(&self.pool)
+        .await?;
+
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl VectorStore for Store {
+    async fn add_documents(
+        &self,
+        docs: &[Document],
+        opt: &VecStoreOptions,
+    ) -> Result<Vec<String>, Box<dyn Error>> {
+        let texts: Vec<String> = docs.iter().map(|d| d.page_content.clone()).collect();
+
+        let embedder = opt.embedder.as_ref().unwrap_or(&self.embedder);
+
+        let vectors = embedder.embed_documents(&texts).await?;
+        if vectors.len() != docs.len() {
+            return Err(Box::new(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                "Number of vectors and documents do not match",
+            )));
+        }
+
+        let table = &self.table;
+
+        let mut tx = self.pool.begin().await?;
+
+        let mut ids = Vec::with_capacity(docs.len());
+
+        for (doc, vector) in docs.iter().zip(vectors.iter()) {
+            let text_embedding = json!(&vector);
+            let id = sqlx::query(&format!(
+                r#"
+                    INSERT INTO {table}
+                        (text, metadata, text_embedding)
+                    VALUES
+                        (?,?,?)"#
+            ))
+            .bind(&doc.page_content)
+            .bind(json!(&doc.metadata))
+            .bind(text_embedding.to_string())
+            .execute(&mut *tx)
+            .await?
+            .last_insert_rowid();
+
+            ids.push(id.to_string());
+        }
+
+        tx.commit().await?;
+
+        Ok(ids)
+    }
+
+    async fn similarity_search(
+        &self,
+        query: &str,
+        limit: usize,
+        _opt: &VecStoreOptions,
+    ) -> Result<Vec<Document>, Box<dyn Error>> {
+        let table = &self.table;
+
+        let query_vector = json!(self.embedder.embed_query(query).await?);
+
+        let rows = sqlx::query(&format!(
+            r#"SELECT
+                    text,
+                    metadata,
+                    distance
+                FROM {table} e
+                INNER JOIN vss_{table} v on v.rowid = e.rowid
+                WHERE vss_search(
+                  v.text_embedding,
+                  vss_search_params('{query_vector}', ?)
+                )
+                LIMIT ?"#
+        ))
+        .bind(limit as i32)
+        .bind(limit as i32)
+        .fetch_all(&self.pool)
+        .await?;
+
+        let docs = rows
+            .into_iter()
+            .map(|row| {
+                let page_content: String = row.try_get("text")?;
+                let metadata_json: Value = row.try_get("metadata")?;
+                let score: f64 = row.try_get("distance")?;
+
+                let metadata = if let Value::Object(obj) = metadata_json {
+                    obj.into_iter().collect()
+                } else {
+                    HashMap::new() // Or handle this case as needed
+                };
+
+                Ok(Document {
+                    page_content,
+                    metadata,
+                    score,
+                })
+            })
+            .collect::<Result<Vec<Document>, sqlx::Error>>()?;
+
+        Ok(docs)
+    }
+}


### PR DESCRIPTION
This should be compatible with langchain python except for the trigger name. I think it is a bug there but not an expert in sqlite. refer to https://github.com/langchain-ai/langchain/blob/b617085af0d14468d5418176d4235229c2c12ffa/libs/community/langchain_community/vectorstores/sqlitevss.py#L26

you do need to manually install sqlite-vss libraries from https://github.com/asg017/sqlite-vss. Easiest way is to download the dynamic libraries and set it in the same path as the binary. your OS might block the libraries since it is download from the internet. I have filed an issue on sqlx site, so we can statically link the extension in the future when it is supported. https://github.com/launchbadge/sqlx/issues/3147

