### PR TITLE
Add support for git commit loader

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ secrecy = "0.8.0"
 readability = "0.3.0"
 url = "2.5.0"
 fastembed = "3.3.0"
+gix = { version = "0.61.0", default-features = false, features = ["parallel", "revision", "serde"] }
 
 [features]
 default = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,13 +42,14 @@ secrecy = "0.8.0"
 readability = "0.3.0"
 url = "2.5.0"
 fastembed = "3.3.0"
-gix = { version = "0.61.0", default-features = false, features = ["parallel", "revision", "serde"] }
+gix = { version = "0.61.0", default-features = false, optional = true, features = ["parallel", "revision", "serde"] }
 
 [features]
 default = []
 postgres = ["pgvector", "sqlx", "uuid"]
 surrealdb = ["dep:surrealdb"]
 sqlite = ["sqlx"]
+git = ["gix"]
 
 [dev-dependencies]
 tokio-test = "0.4.4"

--- a/README.md
+++ b/README.md
@@ -153,6 +153,25 @@ This is the Rust language implementation of [LangChain](https://github.com/langc
     }
     ```
 
+  - [x] Git commits
+
+    ```rust
+    use futures_util::StreamExt;
+
+    async fn main() {
+        let path = "/path/to/git/repo";
+        let git_commit_loader = GitCommitLoader::from_path(path).expect("Failed to create git commit loader");
+
+        let documents = csv_loader
+            .load()
+            .await
+            .unwrap()
+            .map(|x| x.unwrap())
+            .collect::<Vec<_>>()
+            .await;
+    }
+    ```
+
 ## Installation
 
 This library heavily relies on `serde_json` for its operation.

--- a/examples/git_commits.rs
+++ b/examples/git_commits.rs
@@ -1,0 +1,85 @@
+// To run this example execute: cargo run --example git_commits --features sqlite,git -- /path/to/git/repo
+// Make sure vector0 and vss0 libraries are installed in the system or the path of the executable.
+// Download the libraries from https://github.com/asg017/sqlite-vss
+// For static compliation of sqlite-vss extension refer to the following link:
+// https://github.com/launchbadge/sqlx/issues/3147.
+
+#[cfg(feature = "sqlite")]
+use futures_util::StreamExt;
+#[cfg(feature = "sqlite")]
+use langchain_rust::{
+    document_loaders::GitCommitLoader,
+    document_loaders::Loader,
+    embedding::openai::OpenAiEmbedder,
+    vectorstore::{sqlite_vss::StoreBuilder, VecStoreOptions, VectorStore},
+};
+#[cfg(feature = "sqlite")]
+use std::io::Write;
+
+#[cfg(feature = "sqlite")]
+#[tokio::main]
+async fn main() {
+    // Initialize Embedder
+    let embedder = OpenAiEmbedder::default();
+
+    let database_url = std::env::var("DATABASE_URL").unwrap_or("sqlite::memory:".to_string());
+
+    let repo_path = std::env::args()
+        .nth(1)
+        .expect("Please provide the path to the git repository.");
+
+    // Initialize the Sqlite Vector Store
+    let store = StoreBuilder::new()
+        .embedder(embedder)
+        .connection_url(database_url)
+        .table("documents")
+        .vector_dimensions(1536)
+        .build()
+        .await
+        .unwrap();
+
+    // Intialize the tables in the database. This is required to be done only once.
+    store.initialize().await.unwrap();
+
+    let git_commit_loader = GitCommitLoader::from_path(repo_path).unwrap();
+
+    let documents = git_commit_loader
+        .load()
+        .await
+        .unwrap()
+        .map(|x| x.unwrap())
+        .collect::<Vec<_>>()
+        .await;
+
+    store
+        .add_documents(&documents, &VecStoreOptions::default())
+        .await
+        .unwrap();
+
+    // Ask for user input
+    print!("Query> ");
+    std::io::stdout().flush().unwrap();
+    let mut input = String::new();
+    std::io::stdin().read_line(&mut input).unwrap();
+
+    let results = store
+        .similarity_search(&input, 2, &VecStoreOptions::default())
+        .await
+        .unwrap();
+
+    if results.is_empty() {
+        println!("No results found.");
+        return;
+    } else {
+        results.iter().for_each(|r| {
+            println!("Document: {}", r.page_content);
+        });
+    }
+}
+
+#[cfg(not(feature = "sqlite"))]
+fn main() {
+    println!("This example requires the 'sqlite' and 'git' feature to be enabled.");
+    println!("Please run the command as follows:");
+    println!("cargo run --example git_commits --features sqlite,git -- /path/to/git/repo");
+}

--- a/src/document_loaders/error.rs
+++ b/src/document_loaders/error.rs
@@ -27,6 +27,9 @@ pub enum LoaderError {
     #[error(transparent)]
     JoinError(#[from] tokio::task::JoinError),
 
+    #[error(transparent)]
+    DiscoveryError(#[from] gix::discover::Error),
+
     #[error("Error: {0}")]
     OtherError(String),
 }

--- a/src/document_loaders/git_commit_loader/git_commit_loader.rs
+++ b/src/document_loaders/git_commit_loader/git_commit_loader.rs
@@ -53,8 +53,6 @@ impl Loader for GitCommitLoader {
                 "commit {commit_id}\nAuthor: {name} <{email}>\n\n    {message}"
             ));
             let mut metadata = HashMap::new();
-            metadata.insert("name".to_string(), Value::from(name));
-            metadata.insert("email".to_string(), Value::from(email));
             metadata.insert("commit".to_string(), Value::from(commit_id.to_string()));
 
             document.metadata = metadata;
@@ -101,7 +99,6 @@ mod tests {
 
         dbg!(&documents);
         // assert_eq!(documents[0].page_content, "");
-
         todo!()
     }
 }

--- a/src/document_loaders/git_commit_loader/git_commit_loader.rs
+++ b/src/document_loaders/git_commit_loader/git_commit_loader.rs
@@ -1,0 +1,107 @@
+use std::collections::HashMap;
+use std::pin::Pin;
+
+use crate::document_loaders::{process_doc_stream, LoaderError};
+use crate::{document_loaders::Loader, schemas::Document, text_splitter::TextSplitter};
+use async_trait::async_trait;
+use futures::Stream;
+use futures_util::stream;
+use gix::ThreadSafeRepository;
+use serde_json::Value;
+
+#[derive(Clone)]
+pub struct GitCommitLoader {
+    repo: ThreadSafeRepository,
+}
+
+impl GitCommitLoader {
+    pub fn new(repo: ThreadSafeRepository) -> Self {
+        Self { repo }
+    }
+
+    pub fn from_path<P: AsRef<std::path::Path>>(directory: P) -> Result<Self, LoaderError> {
+        let repo = ThreadSafeRepository::discover(directory)?;
+        Ok(Self::new(repo))
+    }
+}
+
+#[async_trait]
+impl Loader for GitCommitLoader {
+    async fn load(
+        mut self,
+    ) -> Result<
+        Pin<Box<dyn Stream<Item = Result<Document, LoaderError>> + Send + 'static>>,
+        LoaderError,
+    > {
+        let repo = self.repo.to_thread_local();
+
+        let revwalk = repo
+            .rev_walk(Some(repo.head_id().unwrap().detach()))
+            .all()
+            .unwrap()
+            .filter_map(Result::ok);
+
+        let commits_iter = revwalk.map(|oid| {
+            let commit = oid.object().unwrap();
+            let commit_id = commit.id;
+            let author = commit.author().unwrap();
+            let email = author.email.to_string();
+            let name = author.name.to_string();
+            let message = format!("{}", commit.message().unwrap().title);
+
+            let mut document = Document::new(format!(
+                "commit {commit_id}\nAuthor: {name} <{email}>\n\n    {message}"
+            ));
+            let mut metadata = HashMap::new();
+            metadata.insert("name".to_string(), Value::from(name));
+            metadata.insert("email".to_string(), Value::from(email));
+            metadata.insert("commit".to_string(), Value::from(commit_id.to_string()));
+
+            document.metadata = metadata;
+            Ok(document)
+        });
+
+        // TODO: This is a temporary solution to collect all the docs as can't share it between threads
+        let documents = commits_iter.collect::<Vec<_>>();
+
+        Ok(Box::pin(stream::iter(documents)))
+    }
+
+    async fn load_and_split<TS: TextSplitter + 'static>(
+        mut self,
+        splitter: TS,
+    ) -> Result<
+        Pin<Box<dyn Stream<Item = Result<Document, LoaderError>> + Send + 'static>>,
+        LoaderError,
+    > {
+        let doc_stream = self.load().await?;
+        let stream = process_doc_stream(doc_stream, splitter).await;
+        Ok(Box::pin(stream))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use futures_util::StreamExt;
+
+    use super::*;
+
+    #[tokio::test]
+    #[ignore]
+    async fn git_commit_loader() {
+        let git_commit_loader = GitCommitLoader::from_path("/code/langchain-rust").unwrap();
+
+        let documents = git_commit_loader
+            .load()
+            .await
+            .unwrap()
+            .map(|x| x.unwrap())
+            .collect::<Vec<_>>()
+            .await;
+
+        dbg!(&documents);
+        // assert_eq!(documents[0].page_content, "");
+
+        todo!()
+    }
+}

--- a/src/document_loaders/git_commit_loader/mod.rs
+++ b/src/document_loaders/git_commit_loader/mod.rs
@@ -1,0 +1,2 @@
+mod git_commit_loader;
+pub use git_commit_loader::*;

--- a/src/document_loaders/mod.rs
+++ b/src/document_loaders/mod.rs
@@ -7,6 +7,9 @@ pub use text_loader::*;
 mod csv_loader;
 pub use csv_loader::*;
 
+mod git_commit_loader;
+pub use git_commit_loader::*;
+
 mod pandoc_loader;
 pub use pandoc_loader::*;
 

--- a/src/document_loaders/mod.rs
+++ b/src/document_loaders/mod.rs
@@ -7,7 +7,9 @@ pub use text_loader::*;
 mod csv_loader;
 pub use csv_loader::*;
 
+#[cfg(feature = "git")]
 mod git_commit_loader;
+#[cfg(feature = "git")]
 pub use git_commit_loader::*;
 
 mod pandoc_loader;


### PR DESCRIPTION
- [x] Add `git` feature flag. This embeds [gix](https://docs.rs/gix/latest/gix/) library so can work without `git` executable. 
- [x] update README.md
- [x] add git_commit example

Test is commented and ignored for now.

Currently all the commits are loaded in memory as gix library when walking iterator is not thread safe.

In the future we can add commit date/time, files that were modified including diff. 