### PR TITLE
feat: added output parser in the chain builder

### DIFF
--- a/src/chain/error.rs
+++ b/src/chain/error.rs
@@ -1,11 +1,14 @@
 use thiserror::Error;
 
-use crate::{language_models::LLMError, prompt::PromptError};
+use crate::{language_models::LLMError, output_parsers::OutputParserError, prompt::PromptError};
 
 #[derive(Error, Debug)]
 pub enum ChainError {
     #[error("LLM error: {0}")]
     LLMError(#[from] LLMError),
+
+    #[error("OutputParser error: {0}")]
+    OutputParser(#[from] OutputParserError),
 
     #[error("Prompt error: {0}")]
     PromptError(#[from] PromptError),

--- a/src/language_models/llm.rs
+++ b/src/language_models/llm.rs
@@ -34,3 +34,12 @@ pub trait LLM: Sync + Send {
             .join("\n")
     }
 }
+
+impl<L> From<L> for Box<dyn LLM>
+where
+    L: 'static + LLM,
+{
+    fn from(llm: L) -> Self {
+        Box::new(llm)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,10 +6,12 @@ pub mod embedding;
 pub mod language_models;
 pub mod llm;
 pub mod memory;
+pub mod output_parsers;
 pub mod prompt;
 pub mod schemas;
 pub mod semantic_router;
 pub mod text_splitter;
 pub mod tools;
 pub mod vectorstore;
+
 pub use url;

--- a/src/llm/openai/mod.rs
+++ b/src/llm/openai/mod.rs
@@ -52,12 +52,6 @@ pub struct OpenAI<C: Config> {
     model: String,
 }
 
-impl<C: Config + Send + Sync + 'static> Into<Box<dyn LLM>> for OpenAI<C> {
-    fn into(self) -> Box<dyn LLM> {
-        Box::new(self)
-    }
-}
-
 impl<C: Config> OpenAI<C> {
     pub fn new(config: C) -> Self {
         Self {

--- a/src/output_parsers/error.rs
+++ b/src/output_parsers/error.rs
@@ -1,0 +1,11 @@
+use regex::Error as RegexError;
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum OutputParserError {
+    #[error("Regex error: {0}")]
+    RegexError(#[from] RegexError),
+
+    #[error("Parsing error: {0}")]
+    ParsingError(String),
+}

--- a/src/output_parsers/markdown_parser.rs
+++ b/src/output_parsers/markdown_parser.rs
@@ -1,0 +1,76 @@
+use async_trait::async_trait;
+use regex::Regex;
+
+use super::{OutputParser, OutputParserError};
+
+pub struct MarkdownParser {
+    expresion: String,
+    trim: bool,
+}
+impl MarkdownParser {
+    pub fn new() -> Self {
+        Self {
+            expresion: r"```(?:\w+)?\s*([\s\S]+?)\s*```".to_string(),
+            trim: false,
+        }
+    }
+
+    pub fn with_custom_expresion(mut self, expresion: &str) -> Self {
+        self.expresion = expresion.to_string();
+        self
+    }
+
+    pub fn with_trim(mut self, trim: bool) -> Self {
+        self.trim = trim;
+        self
+    }
+}
+impl Default for MarkdownParser {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl OutputParser for MarkdownParser {
+    async fn parse(&self, output: &str) -> Result<String, OutputParserError> {
+        let re = Regex::new(r"```(?:\w+)?\s*([\s\S]+?)\s*```")?;
+        if let Some(cap) = re.captures(output) {
+            let find = cap[1].to_string();
+            if self.trim {
+                Ok(find.trim().to_string())
+            } else {
+                Ok(find)
+            }
+        } else {
+            Err(OutputParserError::ParsingError(
+                "No code block found".into(),
+            ))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_markdown_parser_finds_code_block() {
+        let parser = MarkdownParser::new();
+        let markdown_content = r#"
+```rust
+fn main() {
+    println!("Hello, world!");
+}
+```
+"#;
+        let result = parser.parse(markdown_content).await;
+        println!("{:?}", result);
+
+        let correct = r#"fn main() {
+    println!("Hello, world!");
+}"#;
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), correct);
+    }
+}

--- a/src/output_parsers/mod.rs
+++ b/src/output_parsers/mod.rs
@@ -1,0 +1,11 @@
+mod output_parser;
+pub use output_parser::*;
+
+mod markdown_parser;
+pub use markdown_parser::*;
+
+mod simple_parser;
+pub use simple_parser::*;
+
+mod error;
+pub use error::*;

--- a/src/output_parsers/output_parser.rs
+++ b/src/output_parsers/output_parser.rs
@@ -1,0 +1,17 @@
+use async_trait::async_trait;
+
+use super::OutputParserError;
+
+#[async_trait]
+pub trait OutputParser: Send + Sync {
+    async fn parse(&self, output: &str) -> Result<String, OutputParserError>;
+}
+
+impl<P> From<P> for Box<dyn OutputParser>
+where
+    P: OutputParser + 'static,
+{
+    fn from(parser: P) -> Self {
+        Box::new(parser)
+    }
+}

--- a/src/output_parsers/simple_parser.rs
+++ b/src/output_parsers/simple_parser.rs
@@ -1,0 +1,32 @@
+use async_trait::async_trait;
+
+use super::{OutputParser, OutputParserError};
+
+pub struct SimpleParser {
+    trim: bool,
+}
+impl SimpleParser {
+    pub fn new() -> Self {
+        Self { trim: false }
+    }
+    pub fn with_trim(mut self, trim: bool) -> Self {
+        self.trim = trim;
+        self
+    }
+}
+impl Default for SimpleParser {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl OutputParser for SimpleParser {
+    async fn parse(&self, output: &str) -> Result<String, OutputParserError> {
+        if self.trim {
+            Ok(output.trim().to_string())
+        } else {
+            Ok(output.to_string())
+        }
+    }
+}

--- a/src/prompt/chat.rs
+++ b/src/prompt/chat.rs
@@ -19,12 +19,6 @@ pub struct HumanMessagePromptTemplate {
     prompt: PromptTemplate,
 }
 
-impl Into<Box<dyn MessageFormatter>> for HumanMessagePromptTemplate {
-    fn into(self) -> Box<dyn MessageFormatter> {
-        Box::new(self)
-    }
-}
-
 impl HumanMessagePromptTemplate {
     pub fn new(prompt: PromptTemplate) -> Self {
         Self { prompt }
@@ -67,12 +61,6 @@ pub struct SystemMessagePromptTemplate {
     prompt: PromptTemplate,
 }
 
-impl Into<Box<dyn MessageFormatter>> for SystemMessagePromptTemplate {
-    fn into(self) -> Box<dyn MessageFormatter> {
-        Box::new(self)
-    }
-}
-
 impl SystemMessagePromptTemplate {
     pub fn new(prompt: PromptTemplate) -> Self {
         Self { prompt }
@@ -113,12 +101,6 @@ impl MessageFormatter for SystemMessagePromptTemplate {
 #[derive(Clone)]
 pub struct AIMessagePromptTemplate {
     prompt: PromptTemplate,
-}
-
-impl Into<Box<dyn MessageFormatter>> for AIMessagePromptTemplate {
-    fn into(self) -> Box<dyn MessageFormatter> {
-        Box::new(self)
-    }
 }
 
 impl FormatPrompter for AIMessagePromptTemplate {

--- a/src/prompt/mod.rs
+++ b/src/prompt/mod.rs
@@ -18,6 +18,14 @@ pub trait PromptFromatter: Send + Sync {
     fn variables(&self) -> Vec<String>;
     fn format(&self, input_variables: PromptArgs) -> Result<String, PromptError>;
 }
+impl<PA> From<PA> for Box<dyn PromptFromatter>
+where
+    PA: PromptFromatter + 'static,
+{
+    fn from(prompt: PA) -> Self {
+        Box::new(prompt)
+    }
+}
 
 /// Represents a generic template for formatting messages.
 pub trait MessageFormatter: Send + Sync {
@@ -26,8 +34,24 @@ pub trait MessageFormatter: Send + Sync {
     /// Returns a list of required input variable names for the template.
     fn input_variables(&self) -> Vec<String>;
 }
+impl<MF> From<MF> for Box<dyn MessageFormatter>
+where
+    MF: MessageFormatter + 'static,
+{
+    fn from(prompt: MF) -> Self {
+        Box::new(prompt)
+    }
+}
 
 pub trait FormatPrompter: Send + Sync {
     fn format_prompt(&self, input_variables: PromptArgs) -> Result<PromptValue, PromptError>;
     fn get_input_variables(&self) -> Vec<String>;
+}
+impl<FP> From<FP> for Box<dyn FormatPrompter>
+where
+    FP: FormatPrompter + 'static,
+{
+    fn from(prompt: FP) -> Self {
+        Box::new(prompt)
+    }
 }


### PR DESCRIPTION
Made changes in the source code to add output parser in the conversational chain builder. Updated methods in chain builder, SQL database chain builder, and LLM chain builder to include output parser. Added error handling for output parser error in llm and chain module. Added new module output_parsers with simple and markdown parsers. Added tests for markdown parser. Updated prompt chat module to change the conversion from structs to traits using Into to From for better rust convention.

#110