### PR TITLE
chore(deps): Pinned FastEmbed version to "3"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ tokio-stream = "0.1.15"
 secrecy = "0.8.0"
 readability = "0.3.0"
 url = "2.5.0"
-fastembed = "3.3.0"
+fastembed = "3"
 gix = { version = "0.61.0", default-features = false, optional = true, features = ["parallel", "revision", "serde"] }
 
 [features]


### PR DESCRIPTION
## Description
Recently versions of FastEmbed have added some [new quantized models](https://github.com/Anush008/fastembed-rs/blob/ddb09017ef7c8abc6ea09b45c422d01aa502c02a/src/models.rs#L4-L45).

Pinning the version to `"3"` allows users to have access to any newer models that could be added in `v3`.
Breaking changes will always have a major version bump.