### PR TITLE
chore: fix typo "slq_chain" -> "sql_chain"

### DIFF
--- a/examples/sql_chain.rs
+++ b/examples/sql_chain.rs
@@ -1,4 +1,4 @@
-// To run this example execute: cargo run --example slq_chain --features postgres
+// To run this example execute: cargo run --example sql_chain --features postgres
 
 #[cfg(feature = "postgres")]
 use langchain_rust::{


### PR DESCRIPTION
Fixes a typo in a comment in the `sql_chain` example.