### PR TITLE
use channels for git commit loader to stream per commit instead of loading all commits in memory

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ secrecy = "0.8.0"
 readability = "0.3.0"
 url = "2.5.0"
 fastembed = "3"
+flume = { version = "0.11.0", optional = true }
 gix = { version = "0.62.0", default-features = false, optional = true, features = [
   "parallel",
   "revision",
@@ -92,7 +93,7 @@ tree-sitter = [
 ]
 surrealdb = ["dep:surrealdb"]
 sqlite = ["sqlx"]
-git = ["gix"]
+git = ["gix", "flume"]
 opensearch = ["dep:opensearch", "aws-config"]
 qdrant = ["qdrant-client", "uuid"]
 


### PR DESCRIPTION
- [x] use [flume](https://crates.io/crates/flume) channels only when git feature is enabled.
- [x] stream the commits to channel instead of loading all commits in memory
- [x] update example to use while loop to stream so it can work with large git repositories.  