### PR TITLE
Add new GPT4o model.

### DIFF
--- a/src/llm/openai/mod.rs
+++ b/src/llm/openai/mod.rs
@@ -27,6 +27,7 @@ pub enum OpenAIModel {
     Gpt35,
     Gpt4,
     Gpt4Turbo,
+    Gpt4o,
 }
 
 impl ToString for OpenAIModel {
@@ -35,6 +36,7 @@ impl ToString for OpenAIModel {
             OpenAIModel::Gpt35 => "gpt-3.5-turbo".to_string(),
             OpenAIModel::Gpt4 => "gpt-4".to_string(),
             OpenAIModel::Gpt4Turbo => "gpt-4-turbo-preview".to_string(),
+            OpenAIModel::Gpt4o => "gpt-4o".to_string(),
         }
     }
 }


### PR DESCRIPTION
Add the new OpenAI model. I verified that it builds and the AI model string is correct and calls go to the new model. 

Looks like the CI build error is unrelated and is impacting #152 as well.