### PR TITLE
Ollama-rs integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ target/
 Cargo.lock
 .DS_Store
 .fastembed_cache
+.vscode

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,12 +7,7 @@ publish = true
 repository = "https://github.com/Abraxas-365/langchain-rust"
 license = "MIT"
 description = "LangChain for Rust, the easiest way to write LLM-based programs in Rust"
-keywords = [
-  "chain",
-  "chatgpt",
-  "llm",
-  "langchain",
-] # List of keywords related to your crate
+keywords = ["chain", "chatgpt", "llm", "langchain"]
 documentation = "https://langchain-rust.sellie.tech/get-started/quickstart"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -32,16 +27,16 @@ async-openai = "0.21.0"
 mockito = "1.4.0"
 tiktoken-rs = "0.5.8"
 sqlx = { version = "0.7.4", default-features = false, features = [
-  "postgres",
-  "sqlite",
-  "runtime-tokio-native-tls",
-  "json",
-  "uuid",
+    "postgres",
+    "sqlite",
+    "runtime-tokio-native-tls",
+    "json",
+    "uuid",
 ], optional = true }
 uuid = { version = "1.8.0", features = ["v4"], optional = true }
 pgvector = { version = "0.3.2", features = [
-  "postgres",
-  "sqlx",
+    "postgres",
+    "sqlx",
 ], optional = true }
 text-splitter = { version = "0.13", features = ["tiktoken-rs", "markdown"] }
 surrealdb = { version = "1.4.2", optional = true, default-features = false }
@@ -58,13 +53,13 @@ url = "2.5.0"
 fastembed = "3"
 flume = { version = "0.11.0", optional = true }
 gix = { version = "0.62.0", default-features = false, optional = true, features = [
-  "parallel",
-  "revision",
-  "serde",
+    "parallel",
+    "revision",
+    "serde",
 ] }
 opensearch = { version = "2", optional = true, features = ["aws-auth"] }
 aws-config = { version = "1.2", optional = true, features = [
-  "behavior-version-latest",
+    "behavior-version-latest",
 ] }
 glob = "0.3.1"
 strum_macros = "0.26.2"
@@ -77,27 +72,29 @@ tree-sitter-c = { version = "0.21", optional = true }
 tree-sitter-go = { version = "0.21", optional = true }
 tree-sitter-python = { version = "0.21", optional = true }
 tree-sitter-typescript = { version = "0.21", optional = true }
-qdrant-client = {version = "1.8.0", optional = true }
+qdrant-client = { version = "1.8.0", optional = true }
+ollama-rs = { version = "0.1.9", optional = true }
 
 [features]
 default = []
 postgres = ["pgvector", "sqlx", "uuid"]
 tree-sitter = [
-  "cc",
-  "dep:tree-sitter",
-  "dep:tree-sitter-rust",
-  "dep:tree-sitter-cpp",
-  "dep:tree-sitter-javascript",
-  "dep:tree-sitter-c",
-  "dep:tree-sitter-go",
-  "dep:tree-sitter-python",
-  "dep:tree-sitter-typescript",
+    "cc",
+    "dep:tree-sitter",
+    "dep:tree-sitter-rust",
+    "dep:tree-sitter-cpp",
+    "dep:tree-sitter-javascript",
+    "dep:tree-sitter-c",
+    "dep:tree-sitter-go",
+    "dep:tree-sitter-python",
+    "dep:tree-sitter-typescript",
 ]
 surrealdb = ["dep:surrealdb"]
 sqlite = ["sqlx"]
 git = ["gix", "flume"]
 opensearch = ["dep:opensearch", "aws-config"]
 qdrant = ["qdrant-client", "uuid"]
+ollama = ['ollama-rs']
 
 [dev-dependencies]
 tokio-test = "0.4.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,7 +73,10 @@ tree-sitter-go = { version = "0.21", optional = true }
 tree-sitter-python = { version = "0.21", optional = true }
 tree-sitter-typescript = { version = "0.21", optional = true }
 qdrant-client = { version = "1.8.0", optional = true }
-ollama-rs = { version = "0.1.9", optional = true }
+ollama-rs = { version = "0.1.9", optional = true, features = [
+    "stream",
+    "chat-history",
+] }
 
 [features]
 default = []

--- a/README.md
+++ b/README.md
@@ -20,14 +20,14 @@ This is the Rust language implementation of [LangChain](https://github.com/langc
 
   - [x] [OpenAi](https://github.com/Abraxas-365/langchain-rust/blob/main/examples/llm_openai.rs)
   - [x] [Azure OpenAi](https://github.com/Abraxas-365/langchain-rust/blob/main/examples/llm_azure_open_ai.rs)
-  - [x] [Ollama and Compatible Api](https://github.com/Abraxas-365/langchain-rust/blob/main/examples/llm_ollama.rs)
+  - [x] [Ollama](https://github.com/Abraxas-365/langchain-rust/blob/main/examples/llm_ollama.rs)
   - [x] [Anthropic Claude](https://github.com/Abraxas-365/langchain-rust/blob/main/examples/llm_anthropic_claude.rs)
 
 - Embeddings
 
   - [x] [OpenAi](https://github.com/Abraxas-365/langchain-rust/blob/main/examples/embedding_openai.rs)
-  - [x] [Ollama](https://github.com/Abraxas-365/langchain-rust/blob/main/examples/embedding_ollama.rs)
   - [x] [Azure OpenAi](https://github.com/Abraxas-365/langchain-rust/blob/main/examples/embedding_azure_open_ai.rs)
+  - [x] [Ollama](https://github.com/Abraxas-365/langchain-rust/blob/main/examples/embedding_ollama.rs)
   - [x] [Local FastEmbed](https://github.com/Abraxas-365/langchain-rust/blob/main/examples/embedding_fastembed.rs)
 
 - VectorStores

--- a/examples/embedding_ollama.rs
+++ b/examples/embedding_ollama.rs
@@ -6,7 +6,7 @@ use langchain_rust::embedding::{
 async fn main() {
     let ollama = OllamaEmbedder::default().with_model("nomic-embed-text");
 
-    let response = ollama.embed_query("What is the sky blue?").await.unwrap();
+    let response = ollama.embed_query("Why is the sky blue?").await.unwrap();
 
     println!("{:?}", response);
 }

--- a/examples/llm_ollama.rs
+++ b/examples/llm_ollama.rs
@@ -1,18 +1,12 @@
-use langchain_rust::llm::OpenAIConfig;
-
-use langchain_rust::{language_models::llm::LLM, llm::openai::OpenAI};
+use langchain_rust::{
+    language_models::llm::LLM,
+    llm::{ollama::openai::OllamaConfig, openai::OpenAI},
+};
 
 #[tokio::main]
 async fn main() {
-    //Since Ollmama is OpenAi compatible
-    //You can call Ollama this way:
-    let ollama = OpenAI::default()
-        .with_config(
-            OpenAIConfig::default()
-                .with_api_base("http://localhost:11434/v1")
-                .with_api_key("ollama"),
-        )
-        .with_model("llama2");
+    // since Ollama is OpenAI compatible, you can use it as below:
+    let ollama = OpenAI::new(OllamaConfig::default()).with_model("llama2");
 
     let response = ollama.invoke("hola").await.unwrap();
     println!("{}", response);

--- a/examples/llm_ollama.rs
+++ b/examples/llm_ollama.rs
@@ -1,12 +1,8 @@
-use langchain_rust::{
-    language_models::llm::LLM,
-    llm::{ollama::openai::OllamaConfig, openai::OpenAI},
-};
+use langchain_rust::{language_models::llm::LLM, llm::ollama::client::Ollama};
 
 #[tokio::main]
 async fn main() {
-    // since Ollama is OpenAI compatible, you can use it as below:
-    let ollama = OpenAI::new(OllamaConfig::default()).with_model("llama2");
+    let ollama = Ollama::default().with_model("llama3");
 
     let response = ollama.invoke("hola").await.unwrap();
     println!("{}", response);

--- a/src/embedding/error.rs
+++ b/src/embedding/error.rs
@@ -1,4 +1,6 @@
 use async_openai::error::OpenAIError;
+#[cfg(feature = "ollama")]
+use ollama_rs::error::OllamaError;
 use reqwest::{Error as ReqwestError, StatusCode};
 use thiserror::Error;
 
@@ -21,4 +23,8 @@ pub enum EmbedderError {
 
     #[error("FastEmbed error: {0}")]
     FastEmbedError(String),
+
+    #[cfg(feature = "ollama")]
+    #[error("Ollama error: {0}")]
+    OllamaError(#[from] OllamaError),
 }

--- a/src/embedding/mod.rs
+++ b/src/embedding/mod.rs
@@ -1,7 +1,13 @@
+mod error;
+
 pub mod embedder_trait;
 pub use embedder_trait::*;
-mod error;
+
+#[cfg(feature = "ollama")]
 pub mod ollama;
+#[cfg(feature = "ollama")]
+pub use ollama::*;
+
 pub mod openai;
 pub use error::*;
 

--- a/src/language_models/error.rs
+++ b/src/language_models/error.rs
@@ -1,4 +1,6 @@
 use async_openai::error::OpenAIError;
+#[cfg(feature = "ollama")]
+use ollama_rs::error::OllamaError;
 use reqwest::Error as ReqwestError;
 use serde_json::Error as SerdeJsonError;
 use thiserror::Error;
@@ -13,6 +15,10 @@ pub enum LLMError {
 
     #[error("Anthropic error: {0}")]
     AnthropicError(#[from] AnthropicError),
+
+    #[cfg(feature = "ollama")]
+    #[error("Ollama error: {0}")]
+    OllamaError(#[from] OllamaError),
 
     #[error("Network request failed: {0}")]
     RequestError(#[from] ReqwestError),

--- a/src/llm/claude/client.rs
+++ b/src/llm/claude/client.rs
@@ -178,8 +178,8 @@ impl LLM for Claude {
             .build()?;
 
         // Instead of sending the request directly, return a stream wrapper
-        let stream = client.execute(request).await?.bytes_stream();
-
+        let stream = client.execute(request).await?;
+        let stream = stream.bytes_stream();
         // Process each chunk as it arrives
         let processed_stream = stream.then(move |result| {
             async move {

--- a/src/llm/mod.rs
+++ b/src/llm/mod.rs
@@ -3,3 +3,8 @@ pub use openai::*;
 
 pub mod claude;
 pub use claude::*;
+
+#[cfg(feature = "ollama")]
+pub mod ollama;
+#[cfg(feature = "ollama")]
+pub use ollama::*;

--- a/src/llm/mod.rs
+++ b/src/llm/mod.rs
@@ -4,7 +4,5 @@ pub use openai::*;
 pub mod claude;
 pub use claude::*;
 
-#[cfg(feature = "ollama")]
 pub mod ollama;
-#[cfg(feature = "ollama")]
 pub use ollama::*;

--- a/src/llm/ollama/client.rs
+++ b/src/llm/ollama/client.rs
@@ -1,0 +1,121 @@
+use std::sync::Arc;
+
+use crate::{
+    language_models::{llm::LLM, options::CallOptions, GenerateResult, LLMError, TokenUsage},
+    schemas::{Message, MessageType, StreamData},
+};
+use async_trait::async_trait;
+use futures::{Stream, StreamExt};
+use ollama_rs::{
+    error::OllamaError,
+    generation::{
+        chat::{request::ChatMessageRequest, ChatMessage, MessageRole},
+        completion::request::GenerationRequest,
+        options::GenerationOptions,
+    },
+    Ollama as OllamaClient,
+};
+
+use std::pin::Pin;
+
+#[derive(Debug, Clone)]
+pub struct Ollama {
+    pub(crate) client: Arc<OllamaClient>,
+    pub(crate) model: String,
+    pub(crate) options: Option<GenerationOptions>,
+}
+
+/// [llama3](https://ollama.com/library/llama3) is a 8B parameters, 4.7GB model.
+const DEFAULT_MODEL: &str = "llama3";
+
+impl Ollama {
+    pub fn new<S: Into<String>>(
+        client: Arc<OllamaClient>,
+        model: S,
+        options: Option<GenerationOptions>,
+    ) -> Self {
+        Ollama {
+            client,
+            model: model.into(),
+            options,
+        }
+    }
+
+    pub fn with_model<S: Into<String>>(mut self, model: S) -> Self {
+        self.model = model.into();
+        self
+    }
+
+    pub fn with_options(mut self, options: GenerationOptions) -> Self {
+        self.options = Some(options);
+        self
+    }
+
+    fn generate_request(&self, messages: &[Message]) -> ChatMessageRequest {
+        let mapped_messages = messages.iter().map(|message| message.into()).collect();
+        ChatMessageRequest::new(self.model.clone(), mapped_messages)
+    }
+}
+
+impl From<&Message> for ChatMessage {
+    fn from(message: &Message) -> Self {
+        ChatMessage {
+            content: message.content.clone(),
+            images: None,
+            role: message.message_type.clone().into(),
+        }
+    }
+}
+
+impl From<MessageType> for MessageRole {
+    fn from(message_type: MessageType) -> Self {
+        match message_type {
+            MessageType::AIMessage => MessageRole::Assistant, // TODO: !!!
+            MessageType::ToolMessage => MessageRole::Assistant, // TODO: !!!
+            MessageType::SystemMessage => MessageRole::System,
+            MessageType::HumanMessage => MessageRole::User,
+        }
+    }
+}
+
+impl Default for Ollama {
+    fn default() -> Self {
+        let client = Arc::new(OllamaClient::default());
+        Ollama::new(client, String::from(DEFAULT_MODEL), None)
+    }
+}
+
+#[async_trait]
+impl LLM for Ollama {
+    async fn stream(
+        &self,
+        messages: &[Message],
+    ) -> Result<Pin<Box<dyn Stream<Item = Result<StreamData, LLMError>> + Send>>, LLMError> {
+        let request = self.generate_request(messages);
+        let result = self.client.send_chat_messages_stream(request).await?;
+
+        unimplemented!()
+    }
+
+    async fn generate(&self, messages: &[Message]) -> Result<GenerateResult, LLMError> {
+        let request = self.generate_request(messages);
+        let result = self.client.send_chat_messages(request).await?;
+
+        let generation = match result.message {
+            Some(message) => message.content,
+            None => return Err(OllamaError::from("No message in response".to_string()).into()),
+        };
+
+        let tokens = result.final_data.map(|final_data| {
+            let prompt_tokens = final_data.prompt_eval_count as u32;
+            let completion_tokens = final_data.eval_count as u32;
+            TokenUsage {
+                prompt_tokens,
+                completion_tokens,
+                total_tokens: prompt_tokens + completion_tokens,
+            }
+        });
+
+        Ok(GenerateResult { tokens, generation })
+    }
+}

--- a/src/llm/ollama/mod.rs
+++ b/src/llm/ollama/mod.rs
@@ -1,2 +1,4 @@
+#[cfg(feature = "ollama")]
 pub mod client;
+
 pub mod openai;

--- a/src/llm/ollama/mod.rs
+++ b/src/llm/ollama/mod.rs
@@ -1,0 +1,2 @@
+pub mod client;
+pub mod openai;

--- a/src/llm/ollama/openai.rs
+++ b/src/llm/ollama/openai.rs
@@ -1,0 +1,75 @@
+use async_openai::config::Config;
+use reqwest::header::HeaderMap;
+use secrecy::Secret;
+use serde::Deserialize;
+
+const OLLAMA_API_BASE: &str = "http://localhost:11434/v1";
+
+/// Ollama has [OpenAI compatiblity](https://ollama.com/blog/openai-compatibility), meaning that you can use it as an OpenAI API.
+///
+/// This struct implements the `Config` trait of OpenAI, and has the necessary setup for OpenAI configurations for you to use Ollama.
+///
+/// ## Example
+///
+/// ```rs
+/// let ollama = OpenAI::new(OllamaConfig::default()).with_model("llama2");
+/// let response = ollama.invoke("hola").await.unwrap();
+/// ```
+#[derive(Clone, Debug, Deserialize)]
+#[serde(default)]
+pub struct OllamaConfig {
+    api_key: Secret<String>,
+}
+
+impl OllamaConfig {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl Config for OllamaConfig {
+    fn api_key(&self) -> &Secret<String> {
+        &self.api_key
+    }
+
+    fn api_base(&self) -> &str {
+        OLLAMA_API_BASE
+    }
+
+    fn headers(&self) -> HeaderMap {
+        HeaderMap::default()
+    }
+
+    fn query(&self) -> Vec<(&str, &str)> {
+        vec![]
+    }
+
+    fn url(&self, path: &str) -> String {
+        format!("{}{}", self.api_base(), path)
+    }
+}
+
+impl Default for OllamaConfig {
+    fn default() -> Self {
+        Self {
+            api_key: Secret::new("ollama".to_string()),
+        }
+    }
+}
+
+#[cfg(tests)]
+mod tests {
+    use crate::{
+        language_models::llm::LLM,
+        llm::{ollama::openai::OllamaConfig, openai::OpenAI},
+    };
+
+    #[tokio::test]
+    async fn test_ollama_openai() {
+        use super::*;
+
+        let ollama = OpenAI::new(OllamaConfig::default()).with_model("llama2");
+        let response = ollama.invoke("hola").await.unwrap();
+        println!("{}", response);
+    }
+}

--- a/src/llm/ollama/openai.rs
+++ b/src/llm/ollama/openai.rs
@@ -12,8 +12,8 @@ const OLLAMA_API_BASE: &str = "http://localhost:11434/v1";
 /// ## Example
 ///
 /// ```rs
-/// let ollama = OpenAI::new(OllamaConfig::default()).with_model("llama2");
-/// let response = ollama.invoke("hola").await.unwrap();
+/// let ollama = OpenAI::new(OllamaConfig::default()).with_model("llama3");
+/// let response = ollama.invoke("Say hello!").await.unwrap();
 /// ```
 #[derive(Clone, Debug, Deserialize)]
 #[serde(default)]


### PR DESCRIPTION
This PR integrates [Ollama-rs](https://github.com/pepperoni21/ollama-rs) and feature-gates it with the `ollama` feature.

- Re-Implements `OllamaEmbedder` using the new client, the `embedding_ollama.rs` example is working.

- Implements the `language_models::llm::LLM` trait for `Ollama`, the `llm_ollama.rs` example is working.

- Also allows OpenAI compatible Ollama usage by implementing `async_openai::config::Config` for `OllamaConfig`, this part is not feature-gated as it does not require Ollama-rs package.

- Closes #148 : Initially we had talked about adding an option to auto-pull a model if it does not exist and such, but with Ollama-rs integrated, we can simply leave that to the user. The pull code is a simple one-liner using the Ollama-rs client, and our tools request the client be created from the outer scope and passed in using `Arc`. So if one needs to pull a model, they can do it before passing in the model with their own logic (e.g. with retries, timeouts, cancellations)

- Opens up the way for #149 as we will basically have access to function calls when the PR: https://github.com/pepperoni21/ollama-rs/pull/51 is merged!

> [!NOTE]
>
> @prabirshrestha Im currently opening this as a draft, because I couldn't implement the `stream` function for the `LLM` trait, and would like your opinion / help on that part! Ollama-rs has a streaming call itself, and I just have to map the items of this stream to the one that LLM trait wants, but for some reason I couldn't do it yet.
>
> I will still be working on that, but would love your input if any 🙏🏻 
>
> EDIT: Streaming is done.