### PR TITLE
Fix typo in ConversationalChain prompt_builder method name

### DIFF
--- a/src/chain/conversational/mod.rs
+++ b/src/chain/conversational/mod.rs
@@ -52,7 +52,7 @@ pub struct ConversationalChain {
 
 //Conversational Chain is a simple chain to interact with ai as a string of messages
 impl ConversationalChain {
-    pub fn pompt_builder(&self) -> ConversationalChainPromptBuilder {
+    pub fn prompt_builder(&self) -> ConversationalChainPromptBuilder {
         ConversationalChainPromptBuilder::new()
     }
 }


### PR DESCRIPTION
This pull request fixes a typo in the `ConversationalChain` struct where the method name `pompt_builder` was misspelled. The correct method name is `prompt_builder`. 