### PR TITLE
add DuckDuckGoSearchResults Tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ This is the Rust language implementation of [LangChain](https://github.com/langc
 - Tools
 
   - [x] Serpapi/Google
+  - [x] DuckDuckGo Search
   - [x] [Wolfram/Math](https://github.com/Abraxas-365/langchain-rust/blob/main/examples/wolfram_tool.rs)
   - [x] Command line
   - [x] [Text2Speech](https://github.com/Abraxas-365/langchain-rust/blob/main/examples/speech2text_openai.rs)

--- a/examples/open_ai_tools_agent.rs
+++ b/examples/open_ai_tools_agent.rs
@@ -7,7 +7,7 @@ use langchain_rust::{
     llm::openai::OpenAI,
     memory::SimpleMemory,
     prompt_args,
-    tools::{CommandExecutor, SerpApi, Tool},
+    tools::{CommandExecutor, DuckDuckGoSearchResults, SerpApi, Tool},
 };
 
 use serde_json::Value;
@@ -31,6 +31,7 @@ async fn main() {
     let llm = OpenAI::default();
     let memory = SimpleMemory::new();
     let serpapi_tool = SerpApi::default();
+    let duckduckgo_tool = DuckDuckGoSearchResults::default();
     let tool_calc = Date {};
     let command_executor = CommandExecutor::default();
     let agent = OpenAiToolAgentBuilder::new()
@@ -38,6 +39,7 @@ async fn main() {
             Arc::new(serpapi_tool),
             Arc::new(tool_calc),
             Arc::new(command_executor),
+            Arc::new(duckduckgo_tool),
         ])
         .options(ChainCallOptions::new().with_max_tokens(1000))
         .build(llm)

--- a/src/tools/duckduckgo/duckduckgo_search.rs
+++ b/src/tools/duckduckgo/duckduckgo_search.rs
@@ -1,0 +1,156 @@
+use std::{collections::HashMap, error::Error};
+
+use async_trait::async_trait;
+use reqwest::Client;
+use scraper::{Html, Selector};
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use url::Url;
+
+use crate::tools::Tool;
+
+pub struct DuckDuckGoSearchResults {
+    url: String,
+    client: Client,
+    max_results: usize,
+}
+
+impl DuckDuckGoSearchResults {
+    pub fn new() -> Self {
+        Self {
+            client: Client::new(),
+            url: "https://duckduckgo.com/html/".to_string(),
+            max_results: 4,
+        }
+    }
+
+    pub fn with_max_results(mut self, max_results: usize) -> Self {
+        self.max_results = max_results;
+        self
+    }
+
+    pub async fn search(&self, query: &str) -> Result<String, Box<dyn Error>> {
+        let mut url = Url::parse(&self.url)?;
+
+        let mut query_params = HashMap::new();
+        query_params.insert("q", query);
+
+        url.query_pairs_mut().extend_pairs(query_params.iter());
+
+        let response = self.client.get(url).send().await?;
+        let body = response.text().await?;
+        let document = Html::parse_document(&body);
+
+        let result_selector = Selector::parse(".web-result").unwrap();
+        let result_title_selector = Selector::parse(".result__a").unwrap();
+        let result_url_selector = Selector::parse(".result__url").unwrap();
+        let result_snippet_selector = Selector::parse(".result__snippet").unwrap();
+
+        let results = document
+            .select(&result_selector)
+            .map(|result| {
+                let title = result
+                    .select(&result_title_selector)
+                    .next()
+                    .unwrap()
+                    .text()
+                    .collect::<Vec<_>>()
+                    .join("");
+                let link = result
+                    .select(&result_url_selector)
+                    .next()
+                    .unwrap()
+                    .text()
+                    .collect::<Vec<_>>()
+                    .join("")
+                    .trim()
+                    .to_string();
+                let snippet = result
+                    .select(&result_snippet_selector)
+                    .next()
+                    .unwrap()
+                    .text()
+                    .collect::<Vec<_>>()
+                    .join("");
+
+                SearchResult {
+                    title,
+                    link,
+                    snippet,
+                }
+            })
+            .take(self.max_results)
+            .collect::<Vec<_>>();
+
+        Ok(serde_json::to_string(&results)?)
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SearchResult {
+    title: String,
+    link: String,
+    snippet: String,
+}
+
+#[async_trait]
+impl Tool for DuckDuckGoSearchResults {
+    fn name(&self) -> String {
+        String::from("DuckDuckGoSearch")
+    }
+
+    fn description(&self) -> String {
+        String::from(
+            r#""Wrapper for DuckDuckGo Search API. "
+	"Useful for when you need to answer questions about current events. "
+	"Always one of the first options when you need to find information on internet"
+	"Input should be a search query. Output is a JSON array of the query results."#,
+        )
+    }
+
+    async fn run(&self, input: Value) -> Result<String, Box<dyn Error>> {
+        let input = input.as_str().ok_or("Input should be a string")?;
+        self.search(input).await
+    }
+
+    fn parameters(&self) -> Value {
+        let prompt = r#"A wrapper around DuckDuckGo Search.
+            Useful for when you need to answer questions about current events.
+            Input should be a search query. Output is a JSON array of the query results."#;
+
+        json!({
+            "description": prompt,
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "string",
+                    "description": "Search query to look up"
+                }
+            },
+            "required": ["query"]
+        })
+    }
+}
+
+impl Default for DuckDuckGoSearchResults {
+    fn default() -> DuckDuckGoSearchResults {
+        DuckDuckGoSearchResults::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::DuckDuckGoSearchResults;
+
+    #[tokio::test]
+    #[ignore]
+    async fn duckduckgosearch_tool() {
+        let ddg = DuckDuckGoSearchResults::default().with_max_results(5);
+        let s = ddg
+            .search("Who is the current President of Peru?")
+            .await
+            .unwrap();
+
+        println!("{}", s);
+    }
+}

--- a/src/tools/duckduckgo/mod.rs
+++ b/src/tools/duckduckgo/mod.rs
@@ -1,0 +1,2 @@
+mod duckduckgo_search;
+pub use duckduckgo_search::*;

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -10,6 +10,9 @@ pub use scraper::*;
 mod sql;
 pub use sql::*;
 
+mod duckduckgo;
+pub use duckduckgo::*;
+
 mod serpapi;
 pub use serpapi::*;
 


### PR DESCRIPTION
This introduces duck duck go search tool. Here is the langchain python equivalent. https://github.com/langchain-ai/langchain/blob/0214246dc69dd2d4e11fd567308f666c220cfb0d/libs/community/langchain_community/tools/ddg_search/tool.py#L43

I'm only porting DuckDuckGoSearchResults and not DuckDuckGoSearchRun. The main difference between them seems to be one returning JSON while other is returning string. 

My tests with llama3 and mistral both seems to be able to extract information from JSON and return the correct response. Phi3 wasn't good at figuring it out. In the future we can easily add DuckDuckGoSearchRun if needed.