### PR TITLE
fix: make ollama_rs crate visible

### DIFF
--- a/src/llm/ollama/client.rs
+++ b/src/llm/ollama/client.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 use async_trait::async_trait;
 use futures::Stream;
-use ollama_rs::{
+pub use ollama_rs::{
     error::OllamaError,
     generation::{
         chat::{request::ChatMessageRequest, ChatMessage, MessageRole},


### PR DESCRIPTION
Issue: The modules in the ollama_rs library are inaccessible. As a result, creating for example generation options to pass to the `.with_options` method of the Ollama client is not possible.

This pull request resolves the visibility issue with the ollama_rs crate, making it accessible for use.
