### PR TITLE
chore: bump ollama `0.1.9` to `0.2.0`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,7 +73,7 @@ tree-sitter-go = { version = "0.21", optional = true }
 tree-sitter-python = { version = "0.21", optional = true }
 tree-sitter-typescript = { version = "0.21", optional = true }
 qdrant-client = { version = "1.8.0", optional = true }
-ollama-rs = { version = "0.1.9", optional = true, features = [
+ollama-rs = { version = "0.2.0", optional = true, features = [
     "stream",
     "chat-history",
 ] }


### PR DESCRIPTION
The `Ollama` client itself at `0.2.0` is not compatible with `0.1.9`, therefore it becomes a problem when one wants to use Ollama-rs on its own and together with LangChain.