### PR TITLE
Bump Qdrant dependency to 1.9, preemptively fix 1.10 compiler error

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,7 +72,7 @@ tree-sitter-c = { version = "0.21", optional = true }
 tree-sitter-go = { version = "0.21", optional = true }
 tree-sitter-python = { version = "0.21", optional = true }
 tree-sitter-typescript = { version = "0.21", optional = true }
-qdrant-client = { version = "1.8.0", optional = true }
+qdrant-client = { version = "1.9.0", optional = true }
 ollama-rs = { version = "0.2.0", optional = true, features = [
     "stream",
     "chat-history",

--- a/src/vectorstore/qdrant/qdrant.rs
+++ b/src/vectorstore/qdrant/qdrant.rs
@@ -1,4 +1,5 @@
 use async_trait::async_trait;
+use qdrant_client::client::Payload;
 use qdrant_client::qdrant::{Filter, PointStruct, SearchPoints};
 use serde_json::json;
 use std::error::Error;
@@ -47,7 +48,7 @@ impl VectorStore for Store {
 
         for (id, (vector, payload)) in ids.clone().zip(vectors.zip(payloads)) {
             let vector: Vec<f32> = vector.into_iter().map(|f| f as f32).collect();
-            let point = PointStruct::new(id, vector, payload.try_into().unwrap());
+            let point = PointStruct::new(id, vector, Payload::try_from(payload).unwrap());
             points.push(point);
         }
 


### PR DESCRIPTION
This PR does two things.

First of all it bumps the Qdrant client dependency to the latest available; 1.9.

It also preemptively changes the way we convert payloads to prevent a compilation error once Qdrant client 1.10 is released.