### PR TITLE
Bump Qdrant dependency to 1.10 with new API client

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,7 +72,7 @@ tree-sitter-c = { version = "0.21", optional = true }
 tree-sitter-go = { version = "0.21", optional = true }
 tree-sitter-python = { version = "0.21", optional = true }
 tree-sitter-typescript = { version = "0.21", optional = true }
-qdrant-client = { version = "1.9.0", optional = true }
+qdrant-client = { version = "1.10.1", optional = true }
 ollama-rs = { version = "0.2.0", optional = true, features = [
     "stream",
     "chat-history",

--- a/examples/vector_store_qdrant.rs
+++ b/examples/vector_store_qdrant.rs
@@ -4,7 +4,7 @@
 use langchain_rust::{
     embedding::openai::openai_embedder::OpenAiEmbedder,
     schemas::Document,
-    vectorstore::qdrant::{QdrantClient, StoreBuilder},
+    vectorstore::qdrant::{Qdrant, StoreBuilder},
     vectorstore::VectorStore,
 };
 #[cfg(feature = "qdrant")]
@@ -20,12 +20,10 @@ async fn main() {
     // Requires OpenAI API key to be set in the environment variable OPENAI_API_KEY
     let embedder = OpenAiEmbedder::default();
 
-    // Initialize the qdrant_client::QdrantClient
+    // Initialize the qdrant_client::Qdrant
     // Ensure Qdrant is running at localhost, with gRPC port at 6334
     // docker run -p 6334:6334 qdrant/qdrant
-    let client = QdrantClient::from_url("http://localhost:6334")
-        .build()
-        .unwrap();
+    let client = Qdrant::from_url("http://localhost:6334").build().unwrap();
 
     let store = StoreBuilder::new()
         .embedder(embedder)

--- a/src/vectorstore/qdrant/qdrant.rs
+++ b/src/vectorstore/qdrant/qdrant.rs
@@ -7,6 +7,10 @@ use std::sync::Arc;
 
 pub use qdrant_client::Qdrant;
 
+// Re-export now deprecated client with old name to prevent breakage for users
+#[deprecated(note = "use `Qdrant` instead")]
+pub use qdrant_client::Qdrant as QdrantClient;
+
 use crate::{
     embedding::embedder_trait::Embedder,
     schemas::Document,

--- a/src/vectorstore/qdrant/qdrant.rs
+++ b/src/vectorstore/qdrant/qdrant.rs
@@ -1,11 +1,11 @@
 use async_trait::async_trait;
 use qdrant_client::client::Payload;
-use qdrant_client::qdrant::{Filter, PointStruct, SearchPoints};
+use qdrant_client::qdrant::{Filter, PointStruct, SearchPointsBuilder, UpsertPointsBuilder};
 use serde_json::json;
 use std::error::Error;
 use std::sync::Arc;
 
-pub use qdrant_client::client::QdrantClient;
+pub use qdrant_client::Qdrant;
 
 use crate::{
     embedding::embedder_trait::Embedder,
@@ -15,7 +15,7 @@ use crate::{
 use uuid::Uuid;
 
 pub struct Store {
-    pub client: QdrantClient,
+    pub client: Qdrant,
     pub embedder: Arc<dyn Embedder>,
     pub collection_name: String,
     pub content_field: String,
@@ -53,7 +53,7 @@ impl VectorStore for Store {
         }
 
         self.client
-            .upsert_points_blocking(self.collection_name.clone(), None, points, None)
+            .upsert_points(UpsertPointsBuilder::new(&self.collection_name, points).wait(true))
             .await?;
 
         Ok(ids.collect())
@@ -87,18 +87,16 @@ impl VectorStore for Store {
             .map(|f| f as f32)
             .collect();
 
-        let results = self
-            .client
-            .search_points(&SearchPoints {
-                collection_name: self.collection_name.clone(),
-                vector: query_vector,
-                limit: limit as u64,
-                with_payload: Some(true.into()),
-                score_threshold: opt.score_threshold,
-                filter: self.search_filter.clone(),
-                ..Default::default()
-            })
-            .await?;
+        let mut operation =
+            SearchPointsBuilder::new(&self.collection_name, query_vector, limit as u64)
+                .with_payload(true);
+        if let Some(score_threshold) = opt.score_threshold {
+            operation = operation.score_threshold(score_threshold);
+        }
+        if let Some(filter) = &self.search_filter {
+            operation = operation.filter(filter.clone());
+        }
+        let results = self.client.search_points(operation).await?;
 
         let documents = results
             .result


### PR DESCRIPTION
With [Qdrant 1.10](https://github.com/qdrant/qdrant/releases/tag/v1.10.0) we released a new API client for Rust. The client is easier to work with, and more importantly, a lot more robust to prevent breakage with future updates.

This PR bumps the Qdrant client to use the new API client.

Note that this still supports older Qdrant versions before 1.10.

Continuation after: <https://github.com/Abraxas-365/langchain-rust/pull/175>