### PR TITLE
Support adding images to Message and mapping to ollama ChatMessage images.

### DIFF
--- a/src/llm/ollama/client.rs
+++ b/src/llm/ollama/client.rs
@@ -4,6 +4,7 @@ use crate::{
 };
 use async_trait::async_trait;
 use futures::Stream;
+use ollama_rs::generation::images::Image;
 pub use ollama_rs::{
     error::OllamaError,
     generation::{
@@ -57,9 +58,19 @@ impl Ollama {
 
 impl From<&Message> for ChatMessage {
     fn from(message: &Message) -> Self {
+        let images = match message.images.clone() {
+            Some(images) => {
+                let images = images
+                    .iter()
+                    .map(|image| Image::from_base64(image.as_str()))
+                    .collect();
+                Some(images)
+            }
+            None => None,
+        };
         ChatMessage {
             content: message.content.clone(),
-            images: None,
+            images,
             role: message.message_type.clone().into(),
         }
     }

--- a/src/schemas/messages.rs
+++ b/src/schemas/messages.rs
@@ -54,6 +54,7 @@ pub struct Message {
     pub message_type: MessageType,
     pub id: Option<String>,
     pub tool_calls: Option<Value>,
+    pub images: Option<Vec<String>>,
 }
 
 impl Message {
@@ -64,6 +65,7 @@ impl Message {
             message_type: MessageType::HumanMessage,
             id: None,
             tool_calls: None,
+            images: None,
         }
     }
 
@@ -74,6 +76,7 @@ impl Message {
             message_type: MessageType::SystemMessage,
             id: None,
             tool_calls: None,
+            images: None,
         }
     }
 
@@ -84,6 +87,7 @@ impl Message {
             message_type: MessageType::AIMessage,
             id: None,
             tool_calls: None,
+            images: None,
         }
     }
 
@@ -94,6 +98,7 @@ impl Message {
             message_type: MessageType::ToolMessage,
             id: Some(id.into()),
             tool_calls: None,
+            images: None,
         }
     }
 


### PR DESCRIPTION
When I wanted to call the LLaVA model, I found that I could not pass the images to ollama, so I added the images field to the Message struct and implemented the mapping to ollama ChatMessage.