### PR TITLE
fix: claude system message error

### DIFF
--- a/src/llm/claude/client.rs
+++ b/src/llm/claude/client.rs
@@ -123,7 +123,7 @@ impl Claude {
     fn build_payload(&self, messages: &[Message], stream: bool) -> Payload {
         let (system_message, other_messages): (Vec<_>, Vec<_>) = messages
             .into_iter()
-            .partition(|m| m.message_type.clone() as u8 == 0);
+            .partition(|m| m.message_type == MessageType::SystemMessage);
         let mut payload = Payload {
             model: self.model.clone(),
             system: system_message.get(0).map(|m| m.content.clone()),

--- a/src/llm/claude/models.rs
+++ b/src/llm/claude/models.rs
@@ -31,6 +31,8 @@ pub(crate) struct Payload {
     pub messages: Vec<ClaudeMessage>,
     pub max_tokens: u32,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub system: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub stream: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub stop_sequences: Option<Vec<String>>,

--- a/src/schemas/messages.rs
+++ b/src/schemas/messages.rs
@@ -11,7 +11,7 @@ use serde_json::Value;
 /// let ai_message_type = MessageType::AIMessage;
 /// let human_message_type = MessageType::HumanMessage;
 /// ```
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(PartialEq, Eq, Serialize, Deserialize, Debug, Clone)]
 pub enum MessageType {
     #[serde(rename = "system")]
     SystemMessage,


### PR DESCRIPTION
Fixes claude system message error when using it an LLM Agent.

`'messages: Unexpected role "system". The Messages API accepts a top-level 'system' parameter, not "system" as an input message role.'`

How to reproduce error: replace OpenAI with Claude as the LLM in this example:

https://github.com/Abraxas-365/langchain-rust/blob/main/examples/open_ai_tools_agent.rs