### PR TITLE
tool_choice instead of function_call

### DIFF
--- a/src/language_models/options.rs
+++ b/src/language_models/options.rs
@@ -167,7 +167,7 @@ impl CallOptions {
         self.presence_penalty = incoming_options.presence_penalty.or(self.presence_penalty);
         self.function_call_behavior = incoming_options
             .function_call_behavior
-            .or(self.function_call_behavior);
+            .or(self.function_call_behavior.clone());
 
         // For `Vec<String>`, merge if both are Some; prefer incoming if only incoming is Some
         if let Some(mut new_stop_words) = incoming_options.stop_words {

--- a/src/llm/openai/mod.rs
+++ b/src/llm/openai/mod.rs
@@ -269,11 +269,11 @@ impl<C: Config> OpenAI<C> {
             request_builder.tools(functions);
         }
 
-        if let Some(behavior) = self.options.function_call_behavior {
+        if let Some(behavior) = &self.options.function_call_behavior {
             match behavior {
-                FunctionCallBehavior::Auto => request_builder.function_call("auto"),
-                FunctionCallBehavior::None => request_builder.function_call("none"),
-                FunctionCallBehavior::Function(name) => request_builder.function_call(name),
+                FunctionCallBehavior::Auto => request_builder.tool_choice("auto"),
+                FunctionCallBehavior::None => request_builder.tool_choice("none"),
+                FunctionCallBehavior::Named(name) => request_builder.tool_choice(name.as_str()),
             };
         }
         request_builder.messages(messages);

--- a/src/llm/openai/mod.rs
+++ b/src/llm/openai/mod.rs
@@ -273,6 +273,8 @@ impl<C: Config> OpenAI<C> {
             match behavior {
                 FunctionCallBehavior::Auto => request_builder.function_call("auto"),
                 FunctionCallBehavior::None => request_builder.function_call("none"),
+                FunctionCallBehavior::Function(name) => request_builder.function_call(name),
+
             };
         }
         request_builder.messages(messages);

--- a/src/llm/openai/mod.rs
+++ b/src/llm/openai/mod.rs
@@ -274,7 +274,6 @@ impl<C: Config> OpenAI<C> {
                 FunctionCallBehavior::Auto => request_builder.function_call("auto"),
                 FunctionCallBehavior::None => request_builder.function_call("none"),
                 FunctionCallBehavior::Function(name) => request_builder.function_call(name),
-
             };
         }
         request_builder.messages(messages);

--- a/src/schemas/tools_openai_like.rs
+++ b/src/schemas/tools_openai_like.rs
@@ -5,11 +5,11 @@ use serde_json::Value;
 
 use crate::tools::Tool;
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Debug)]
 pub enum FunctionCallBehavior {
     None,
     Auto,
-    Function(&'static str),
+    Named(String),
 }
 
 #[derive(Clone, Debug)]

--- a/src/schemas/tools_openai_like.rs
+++ b/src/schemas/tools_openai_like.rs
@@ -9,6 +9,7 @@ use crate::tools::Tool;
 pub enum FunctionCallBehavior {
     None,
     Auto,
+    Function(&'static str),
 }
 
 #[derive(Clone, Debug)]


### PR DESCRIPTION
We have to change to tool_choice, because the functions are inserted as tools.
I also added the named options to force the LLM to use a tool.