### PR TITLE
set default model to gtp4omini

### DIFF
--- a/src/llm/openai/mod.rs
+++ b/src/llm/openai/mod.rs
@@ -61,7 +61,7 @@ impl<C: Config> OpenAI<C> {
         Self {
             config,
             options: CallOptions::default(),
-            model: OpenAIModel::Gpt35.to_string(),
+            model: OpenAIModel::Gpt4oMini.to_string(),
         }
     }
 


### PR DESCRIPTION
Set the default model to gpt4o mini  as it is cheaper, more capable, multimodal, and just as fast. See [Model Overview](https://platform.openai.com/docs/models/gpt-3-5-turbo)