### PR TITLE
add pdf-extract loader

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,8 @@ text-splitter = { version = "0.15", features = ["tiktoken-rs", "markdown"] }
 surrealdb = { version = "1.4.2", optional = true, default-features = false }
 csv = "1.3.0"
 urlencoding = "2.1.3"
-lopdf = { version = "0.33.0", features = ["pom", "pom_parser"], optional = true }
+lopdf = { version = "0.32.0", features = ["nom_parser"], optional = true }
+pdf-extract = { version = "0.7.7", optional = true  }
 thiserror = "1.0.59"
 futures-util = "0.3.30"
 async-stream = "0.3.5"
@@ -85,6 +86,7 @@ fastembed = ["dep:fastembed"]
 git = ["gix", "flume"]
 mistralai = ["mistralai-client"]
 lopdf = ["dep:lopdf"]
+pdf-extract = ["dep:lopdf", "dep:pdf-extract"]
 ollama = ["ollama-rs"]
 opensearch = ["dep:opensearch", "aws-config"]
 postgres = ["pgvector", "sqlx", "uuid"]

--- a/README.md
+++ b/README.md
@@ -77,7 +77,8 @@ This is the Rust language implementation of [LangChain](https://github.com/langc
     async fn main() {
         let path = "./src/document_loaders/test_data/sample.pdf";
 
-        let loader = LoPdfLoader::from_path(path).expect("Failed to create PdfLoader");
+        let loader = PdfExtractLoader::from_path(path).expect("Failed to create PdfExtractLoader");
+        // let loader = LoPdfLoader::from_path(path).expect("Failed to create LoPdfLoader");
 
         let docs = loader
             .load()

--- a/src/document_loaders/error.rs
+++ b/src/document_loaders/error.rs
@@ -1,4 +1,4 @@
-use std::io;
+use std::{io, string::FromUtf8Error};
 
 use thiserror::Error;
 
@@ -16,11 +16,18 @@ pub enum LoaderError {
     IOError(#[from] io::Error),
 
     #[error(transparent)]
+    FromUtf8Error(#[from] FromUtf8Error),
+
+    #[error(transparent)]
     CSVError(#[from] csv::Error),
 
     #[cfg(feature = "lopdf")]
     #[error(transparent)]
     LoPdfError(#[from] lopdf::Error),
+
+    #[cfg(feature = "pdf-extract")]
+    #[error(transparent)]
+    PdfExtractOutputError(#[from] pdf_extract::OutputError),
 
     #[error(transparent)]
     ReadabilityError(#[from] readability::error::Error),

--- a/src/document_loaders/mod.rs
+++ b/src/document_loaders/mod.rs
@@ -15,9 +15,9 @@ pub use git_commit_loader::*;
 mod pandoc_loader;
 pub use pandoc_loader::*;
 
-#[cfg(feature = "lopdf")]
+#[cfg(any(feature = "lopdf", feature = "pdf_extract"))]
 mod pdf_loader;
-#[cfg(feature = "lopdf")]
+#[cfg(any(feature = "lopdf", feature = "pdf_extract"))]
 pub use pdf_loader::*;
 
 mod html_loader;

--- a/src/document_loaders/pdf_loader/mod.rs
+++ b/src/document_loaders/pdf_loader/mod.rs
@@ -1,2 +1,5 @@
 #[cfg(feature = "lopdf")]
 pub mod lo_loader;
+
+#[cfg(feature = "pdf-extract")]
+pub mod pdf_extract_loader;


### PR DESCRIPTION
Adding a new pdf-extract loader as using lopdf directly it couldn't load some files.

Had to bump the version of lopdf down as pdf-extract uses a lower version. Ideally if pdf-extract exposed lopdf::Document then we didn't have to decrease the version - https://github.com/jrmuizel/pdf-extract/pull/44

To extract by pages need https://github.com/jrmuizel/pdf-extract/pull/93.