### PR TITLE
add #[derive(Debug)] for AgentEvent

### DIFF
--- a/src/schemas/agent.rs
+++ b/src/schemas/agent.rs
@@ -28,6 +28,7 @@ pub struct AgentFinish {
     pub output: String,
 }
 
+#[derive(Debug)]
 pub enum AgentEvent {
     Action(Vec<AgentAction>),
     Finish(AgentFinish),


### PR DESCRIPTION
Noticed this when trying to debug the library. 