### PR TITLE
Support image messages for OpenAI

### DIFF
--- a/examples/vision_llm_chain.rs
+++ b/examples/vision_llm_chain.rs
@@ -1,0 +1,34 @@
+use langchain_rust::chain::{Chain, LLMChainBuilder};
+use langchain_rust::llm::OpenAI;
+use langchain_rust::prompt::HumanMessagePromptTemplate;
+use langchain_rust::schemas::Message;
+use langchain_rust::{fmt_message, fmt_template, message_formatter, prompt_args, template_fstring};
+
+#[tokio::main]
+async fn main() {
+    // Or can be a base64 encoded string of the image
+    let image_url = "https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/Gfp-wisconsin-madison-the-nature-boardwalk.jpg/2560px-Gfp-wisconsin-madison-the-nature-boardwalk.jpg";
+    let prompt = message_formatter![
+        fmt_template!(HumanMessagePromptTemplate::new(template_fstring!(
+            "{input}", "input"
+        ))),
+        fmt_message!(Message::new_human_message_with_images(vec![image_url])),
+    ];
+
+    let open_ai = OpenAI::default();
+    let chain = LLMChainBuilder::new()
+        .prompt(prompt)
+        .llm(open_ai)
+        .build()
+        .unwrap();
+
+    match chain
+        .invoke(prompt_args! { "input" => "Describe this image"})
+        .await
+    {
+        Ok(result) => {
+            println!("Result: {:?}", result);
+        }
+        Err(e) => panic!("Error invoking LLMChain: {:?}", e),
+    }
+}

--- a/src/llm/openai/mod.rs
+++ b/src/llm/openai/mod.rs
@@ -295,7 +295,7 @@ mod tests {
 
     #[test]
     #[ignore]
-    async fn test_ivoke() {
+    async fn test_invoke() {
         let message_complete = Arc::new(Mutex::new(String::new()));
 
         // Define the streaming function

--- a/src/schemas/messages.rs
+++ b/src/schemas/messages.rs
@@ -40,6 +40,22 @@ impl MessageType {
     }
 }
 
+/// Struct `ImageContent` represents an image provided to an LLM.
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
+pub struct ImageContent {
+    pub image_url: String,
+    pub detail: Option<String>,
+}
+
+impl<S: AsRef<str>> From<S> for ImageContent {
+    fn from(image_url: S) -> Self {
+        ImageContent {
+            image_url: image_url.as_ref().into(),
+            detail: None,
+        }
+    }
+}
+
 /// Struct `Message` represents a message with its content and type.
 ///
 /// # Usage
@@ -54,7 +70,7 @@ pub struct Message {
     pub message_type: MessageType,
     pub id: Option<String>,
     pub tool_calls: Option<Value>,
-    pub images: Option<Vec<String>>,
+    pub images: Option<Vec<ImageContent>>,
 }
 
 impl Message {
@@ -66,6 +82,16 @@ impl Message {
             id: None,
             tool_calls: None,
             images: None,
+        }
+    }
+
+    pub fn new_human_message_with_images<T: Into::<ImageContent>>(images: Vec<T>) -> Self {
+        Message {
+            content: String::default(),
+            message_type: MessageType::HumanMessage,
+            id: None,
+            tool_calls: None,
+            images: Some(images.into_iter().map(|i| i.into()).collect()),
         }
     }
 


### PR DESCRIPTION
Allows sending images, either URLs or Base64 strings, to OpenAI. This enables support for OpenAI's [vision capabilities](https://platform.openai.com/docs/guides/vision), similar to the support added for Ollama [here](https://github.com/Abraxas-365/langchain-rust/pull/179).

I'm relatively new to Rust and I'm open to feedback about my approach, so please review with a critical eye. Thanks!