### PR TITLE
fix: allow ConversationalAgentBuilder to be built using a dynamic LLM…

### DIFF
--- a/src/agent/chat/builder.rs
+++ b/src/agent/chat/builder.rs
@@ -50,7 +50,7 @@ impl ConversationalAgentBuilder {
         self
     }
 
-    pub fn build<L: LLM + 'static>(self, llm: L) -> Result<ConversationalAgent, AgentError> {
+    pub fn build<L: Into<Box<dyn LLM>>>(self, llm: L) -> Result<ConversationalAgent, AgentError> {
         let tools = self.tools.unwrap_or_default();
         let prefix = self.prefix.unwrap_or_else(|| PREFIX.to_string());
         let suffix = self.suffix.unwrap_or_else(|| SUFFIX.to_string());


### PR DESCRIPTION
It's currently not possible to create a `ConversationalAgent` using the `ConversationalAgentBuilder` if the `LLM` instance is not static. This Pull-Request fix that.

Usage example:

```rust
let llm: Box<dyn LLM> = self.llm_factory.create(CreateLLMParameters {
    model: parameters.model, // openai:gpt-4o-mini or anthropic:claude-xyz
})?;

let agent = ConversationalAgentBuilder::new().build(llm).unwrap();
```