### PR TITLE
default to llama 3.2 for ollama

### DIFF
--- a/examples/llm_ollama.rs
+++ b/examples/llm_ollama.rs
@@ -4,7 +4,7 @@ use langchain_rust::{language_models::llm::LLM, llm::ollama::client::Ollama};
 #[cfg(feature = "ollama")]
 #[tokio::main]
 async fn main() {
-    let ollama = Ollama::default().with_model("llama3");
+    let ollama = Ollama::default().with_model("llama3.2");
 
     let response = ollama.invoke("Hi").await.unwrap();
     println!("{}", response);

--- a/src/llm/ollama/client.rs
+++ b/src/llm/ollama/client.rs
@@ -24,8 +24,8 @@ pub struct Ollama {
     pub(crate) options: Option<GenerationOptions>,
 }
 
-/// [llama3](https://ollama.com/library/llama3) is a 8B parameters, 4.7GB model.
-const DEFAULT_MODEL: &str = "llama3";
+/// [llama3.2](https://ollama.com/library/llama3.2) is a 3B parameters, 2.0GB model.
+const DEFAULT_MODEL: &str = "llama3.2";
 
 impl Ollama {
     pub fn new<S: Into<String>>(
@@ -152,7 +152,7 @@ mod tests {
     #[tokio::test]
     #[ignore]
     async fn test_generate() {
-        let ollama = Ollama::default().with_model("llama3");
+        let ollama = Ollama::default().with_model("llama3.2");
         let response = ollama.invoke("Hey Macarena, ay").await.unwrap();
         println!("{}", response);
     }
@@ -160,7 +160,7 @@ mod tests {
     #[tokio::test]
     #[ignore]
     async fn test_stream() {
-        let ollama = Ollama::default().with_model("llama3");
+        let ollama = Ollama::default().with_model("llama3.2");
 
         let message = Message::new_human_message("Why does water boil at 100 degrees?");
         let mut stream = ollama.stream(&vec![message]).await.unwrap();

--- a/src/llm/ollama/openai.rs
+++ b/src/llm/ollama/openai.rs
@@ -12,7 +12,7 @@ const OLLAMA_API_BASE: &str = "http://localhost:11434/v1";
 /// ## Example
 ///
 /// ```rs
-/// let ollama = OpenAI::new(OllamaConfig::default()).with_model("llama3");
+/// let ollama = OpenAI::new(OllamaConfig::default()).with_model("llama3.2");
 /// let response = ollama.invoke("Say hello!").await.unwrap();
 /// ```
 #[derive(Clone, Debug, Deserialize)]


### PR DESCRIPTION
Default to llama3.2 for ollama since it is very fast and supports tooling including those running in just CPU. In my test 1b seems to fails at following instructions on JSON so sticking with 3b.