### PR TITLE
Fix redundant double-quoting in pgvector filters #268

### DIFF
--- a/src/vectorstore/pgvector/pgvector.rs
+++ b/src/vectorstore/pgvector/pgvector.rs
@@ -168,7 +168,13 @@ impl VectorStore for Store {
         let filter = self.get_filters(opt)?;
         let mut where_querys = filter
             .iter()
-            .map(|(k, v)| format!("(data.cmetadata ->> '{}') = '{}'", k, v))
+            .map(|(k, v)| {
+                format!(
+                    "(data.cmetadata ->> '{}') = '{}'",
+                    k,
+                    v.to_string().trim_matches('"')
+                )
+            })
             .collect::<Vec<String>>()
             .join(" AND ");
 


### PR DESCRIPTION
This change seems to fix the issue #268 , but I want to note that it's likely a symptom, not a core issue. The current design forces the user to have a "strongly"-typed metadata implementation instead of relying on rust datatypes with macro-base Serialize/Deserialize implementations. As a thought, it may be better to update the VectorStore trait with the associated type for Metadata.