### PR TITLE
Add flexibility to Store trait + better pgvector filtering

### DIFF
--- a/src/vectorstore/opensearch/opensearch.rs
+++ b/src/vectorstore/opensearch/opensearch.rs
@@ -99,10 +99,12 @@ impl Store {
 
 #[async_trait]
 impl VectorStore for Store {
+    type Options = VecStoreOptions<Value>;
+
     async fn add_documents(
         &self,
         docs: &[Document],
-        opt: &VecStoreOptions,
+        opt: &Self::Options,
     ) -> Result<Vec<String>, Box<dyn Error>> {
         let texts: Vec<String> = docs.iter().map(|d| d.page_content.clone()).collect();
         let embedder = opt.embedder.as_ref().unwrap_or(&self.embedder);
@@ -154,7 +156,7 @@ impl VectorStore for Store {
         &self,
         query: &str,
         limit: usize,
-        opt: &VecStoreOptions,
+        opt: &Self::Options,
     ) -> Result<Vec<Document>, Box<dyn Error>> {
         let query_vector = self.embedder.embed_query(query).await?;
         let query = build_similarity_search_query(

--- a/src/vectorstore/options.rs
+++ b/src/vectorstore/options.rs
@@ -16,20 +16,20 @@ use crate::embedding::embedder_trait::Embedder;
 ///     .with_filters(json!({"genre": "Sci-Fi"}))
 ///     .with_embedder(my_embedder);
 /// ```
-pub struct VecStoreOptions {
+pub struct VecStoreOptions<F> {
     pub name_space: Option<String>,
     pub score_threshold: Option<f32>,
-    pub filters: Option<Value>,
+    pub filters: Option<F>,
     pub embedder: Option<Arc<dyn Embedder>>,
 }
 
-impl Default for VecStoreOptions {
+impl Default for VecStoreOptions<Value> {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl VecStoreOptions {
+impl<F> VecStoreOptions<F> {
     pub fn new() -> Self {
         VecStoreOptions {
             name_space: None,
@@ -49,7 +49,7 @@ impl VecStoreOptions {
         self
     }
 
-    pub fn with_filters(mut self, filters: Value) -> Self {
+    pub fn with_filters(mut self, filters: F) -> Self {
         self.filters = Some(filters);
         self
     }

--- a/src/vectorstore/pgvector/builder.rs
+++ b/src/vectorstore/pgvector/builder.rs
@@ -93,7 +93,7 @@ impl StoreBuilder {
         self
     }
 
-    fn collecion_metadata(mut self, collecion_metadata: HashMap<String, Value>) -> Self {
+    fn collection_metadata(mut self, collecion_metadata: HashMap<String, Value>) -> Self {
         self.collection_metadata = collecion_metadata;
         self
     }

--- a/src/vectorstore/pgvector/builder.rs
+++ b/src/vectorstore/pgvector/builder.rs
@@ -6,7 +6,8 @@ use sqlx::{postgres::PgPoolOptions, Pool, Postgres, Row, Transaction};
 use crate::{embedding::embedder_trait::Embedder, vectorstore::VecStoreOptions};
 
 use super::{
-    HNSWIndex, Store, PG_LOCKID_EXTENSION, PG_LOCK_ID_COLLECTION_TABLE, PG_LOCK_ID_EMBEDDING_TABLE,
+    HNSWIndex, PgFilter, PgOptions, Store, PG_LOCKID_EXTENSION, PG_LOCK_ID_COLLECTION_TABLE,
+    PG_LOCK_ID_EMBEDDING_TABLE,
 };
 
 const DEFAULT_COLLECTION_NAME: &str = "langchain";
@@ -14,7 +15,7 @@ const DEFAULT_PRE_DELETE_COLLECTION: bool = false;
 const DEFAULT_EMBEDDING_STORE_TABLE_NAME: &str = "langchain_pg_embedding";
 const DEFAULT_COLLECTION_STORE_TABLE_NAME: &str = "langchain_pg_collection";
 
-pub struct StoreBuilder {
+pub struct StoreBuilder<F> {
     pool: Option<Pool<Postgres>>,
     embedder: Option<Arc<dyn Embedder>>,
     connection_url: Option<String>,
@@ -25,11 +26,11 @@ pub struct StoreBuilder {
     collection_uuid: String,
     collection_table_name: String,
     collection_metadata: HashMap<String, Value>,
-    vstore_options: VecStoreOptions,
+    vstore_options: VecStoreOptions<F>,
     hns_index: Option<HNSWIndex>,
 }
 
-impl StoreBuilder {
+impl StoreBuilder<PgFilter> {
     // Returns a new StoreBuilder instance with default values for each option
     pub fn new() -> Self {
         StoreBuilder {
@@ -43,7 +44,7 @@ impl StoreBuilder {
             collection_name: DEFAULT_COLLECTION_NAME.into(),
             collection_table_name: DEFAULT_COLLECTION_STORE_TABLE_NAME.into(),
             collection_metadata: HashMap::new(),
-            vstore_options: VecStoreOptions::default(),
+            vstore_options: VecStoreOptions::new(),
             hns_index: None,
         }
     }
@@ -88,7 +89,7 @@ impl StoreBuilder {
         self
     }
 
-    pub fn vstore_options(mut self, vstore_options: VecStoreOptions) -> Self {
+    pub fn vstore_options(mut self, vstore_options: PgOptions) -> Self {
         self.vstore_options = vstore_options;
         self
     }

--- a/src/vectorstore/qdrant/qdrant.rs
+++ b/src/vectorstore/qdrant/qdrant.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
 use qdrant_client::client::Payload;
 use qdrant_client::qdrant::{Filter, PointStruct, SearchPointsBuilder, UpsertPointsBuilder};
-use serde_json::json;
+use serde_json::{json, Value};
 use std::error::Error;
 use std::sync::Arc;
 
@@ -27,14 +27,18 @@ pub struct Store {
     pub search_filter: Option<Filter>,
 }
 
+type QdrantOptions = VecStoreOptions<Value>;
+
 #[async_trait]
 impl VectorStore for Store {
+    type Options = QdrantOptions;
+
     /// Add documents to the store.
     /// Returns a list of document IDs added to the Qdrant collection.
     async fn add_documents(
         &self,
         docs: &[Document],
-        opt: &VecStoreOptions,
+        opt: &QdrantOptions,
     ) -> Result<Vec<String>, Box<dyn Error>> {
         let embedder = opt.embedder.as_ref().unwrap_or(&self.embedder);
         let texts: Vec<String> = docs.iter().map(|d| d.page_content.clone()).collect();
@@ -69,7 +73,7 @@ impl VectorStore for Store {
         &self,
         query: &str,
         limit: usize,
-        opt: &VecStoreOptions,
+        opt: &QdrantOptions,
     ) -> Result<Vec<Document>, Box<dyn Error>> {
         if opt.name_space.is_some() {
             return Err("Qdrant doesn't support namespaces".into());

--- a/src/vectorstore/sqlite_vec/sqlite_vec.rs
+++ b/src/vectorstore/sqlite_vec/sqlite_vec.rs
@@ -17,6 +17,8 @@ pub struct Store {
     pub(crate) embedder: Arc<dyn Embedder>,
 }
 
+pub type SqliteOptions = VecStoreOptions<Value>;
+
 impl Store {
     pub async fn initialize(&self) -> Result<(), Box<dyn Error>> {
         self.create_table_if_not_exists().await?;
@@ -70,7 +72,7 @@ impl Store {
         Ok(())
     }
 
-    fn get_filters(&self, opt: &VecStoreOptions) -> Result<HashMap<String, Value>, Box<dyn Error>> {
+    fn get_filters(&self, opt: &SqliteOptions) -> Result<HashMap<String, Value>, Box<dyn Error>> {
         match &opt.filters {
             Some(Value::Object(map)) => {
                 // Convert serde_json Map to HashMap<String, Value>
@@ -85,10 +87,12 @@ impl Store {
 
 #[async_trait]
 impl VectorStore for Store {
+    type Options = SqliteOptions;
+
     async fn add_documents(
         &self,
         docs: &[Document],
-        opt: &VecStoreOptions,
+        opt: &Self::Options,
     ) -> Result<Vec<String>, Box<dyn Error>> {
         let texts: Vec<String> = docs.iter().map(|d| d.page_content.clone()).collect();
 
@@ -136,7 +140,7 @@ impl VectorStore for Store {
         &self,
         query: &str,
         limit: usize,
-        opt: &VecStoreOptions,
+        opt: &Self::Options,
     ) -> Result<Vec<Document>, Box<dyn Error>> {
         let table = &self.table;
 

--- a/src/vectorstore/sqlite_vss/sqlite_vss.rs
+++ b/src/vectorstore/sqlite_vss/sqlite_vss.rs
@@ -17,6 +17,8 @@ pub struct Store {
     pub(crate) embedder: Arc<dyn Embedder>,
 }
 
+pub type SqliteVssOptions = VecStoreOptions<Value>;
+
 impl Store {
     pub async fn initialize(&self) -> Result<(), Box<dyn Error>> {
         self.create_table_if_not_exists().await?;
@@ -73,10 +75,12 @@ impl Store {
 
 #[async_trait]
 impl VectorStore for Store {
+    type Options = SqliteVssOptions;
+
     async fn add_documents(
         &self,
         docs: &[Document],
-        opt: &VecStoreOptions,
+        opt: &Self::Options,
     ) -> Result<Vec<String>, Box<dyn Error>> {
         let texts: Vec<String> = docs.iter().map(|d| d.page_content.clone()).collect();
 
@@ -124,7 +128,7 @@ impl VectorStore for Store {
         &self,
         query: &str,
         limit: usize,
-        _opt: &VecStoreOptions,
+        _opt: &Self::Options,
     ) -> Result<Vec<Document>, Box<dyn Error>> {
         let table = &self.table;
 

--- a/src/vectorstore/surrealdb/surrealdb.rs
+++ b/src/vectorstore/surrealdb/surrealdb.rs
@@ -91,10 +91,12 @@ impl<C: Connection> Store<C> {
 
 #[async_trait]
 impl<C: Connection> VectorStore for Store<C> {
+    type Options = VecStoreOptions<Value>;
+
     async fn add_documents(
         &self,
         docs: &[Document],
-        opt: &VecStoreOptions,
+        opt: &Self::Options,
     ) -> Result<Vec<String>, Box<dyn Error>> {
         let texts: Vec<String> = docs.iter().map(|d| d.page_content.clone()).collect();
 
@@ -169,7 +171,7 @@ impl<C: Connection> VectorStore for Store<C> {
         &self,
         query: &str,
         limit: usize,
-        opt: &VecStoreOptions,
+        opt: &Self::Options,
     ) -> Result<Vec<Document>, Box<dyn Error>> {
         let collection_name = &self.collection_name;
         let collection_table_name = self.get_collection_table_name();


### PR DESCRIPTION
I was using the library to implement a RAG-application with a `pgvector` vector store. Current implementation was lacking in filtering facility for `pgvector`, and only allows for equality comparisons chained with `AND` in sql. Filtering is abstracted over a serializable JSON AST (`serde_json::Value`), which may be appropriate for some of the vector store implementations in the library, but not for all. I reasoned that adding an associated type to the trait would be the most logical way to approach it since it allows us to implement custom filtering for some of the stores (as I do with `pgvector` in this PR) but keep the old behavior for others. 

I also added an implementation of `pgvector` filter that fits my needs, and allows for further extendability. Please see the following links to see how it may be used by the library user (my repo is using the fork of `langchain-rust` with this branch):
1. https://github.com/dredozubov/advisor/blob/master/src/eval.rs#L170
2. https://github.com/dredozubov/advisor/blob/master/src/eval.rs#L204
3. https://github.com/dredozubov/advisor/blob/5d7c1440120d8a5483cbfb847b0a33c8dbff0b7b/src/edgar/filing.rs#L625

I'm happy to hear your thoughts, further walk you through my thought process, and discuss the potential design issues. @Abraxas-365 @prabirshrestha



