### PR TITLE
Add half-streaming agents

### DIFF
--- a/src/agent/executor.rs
+++ b/src/agent/executor.rs
@@ -1,11 +1,14 @@
+use std::pin::Pin;
 use std::{collections::HashMap, sync::Arc};
 
+use async_stream::stream;
 use async_trait::async_trait;
-use serde_json::json;
+use futures::Stream;
+use serde_json::{json, Value};
 use tokio::sync::Mutex;
 
 use super::{agent::Agent, AgentError};
-use crate::schemas::{LogTools, Message};
+use crate::schemas::{LogTools, Message, StreamData};
 use crate::{
     chain::{chain_trait::Chain, ChainError},
     language_models::GenerateResult,
@@ -170,5 +173,163 @@ where
     async fn invoke(&self, input_variables: PromptArgs) -> Result<String, ChainError> {
         let result = self.call(input_variables).await?;
         Ok(result.generation)
+    }
+
+    async fn stream<'life>(
+        &'life self,
+        input_variables: PromptArgs,
+    ) -> Result<Pin<Box<dyn Stream<Item = Result<StreamData, ChainError>> + Send + 'life>>, ChainError>
+    {
+        let mut input_variables = input_variables.clone();
+        let name_to_tools = self.get_name_to_tools();
+        let mut steps: Vec<(AgentAction, String)> = Vec::new();
+        log::debug!("steps: {:?}", steps);
+        if let Some(memory) = &self.memory {
+            let memory = memory.lock().await;
+            input_variables.insert("chat_history".to_string(), json!(memory.messages()));
+        } else {
+            input_variables.insert(
+                "chat_history".to_string(),
+                json!(SimpleMemory::new().messages()),
+            );
+        }
+
+        // let my_agent = self.agent.clone();
+
+        let main_stream = stream! {
+
+            // pin_mut!(steps);
+            // let input_variables = pin!(input_variables);
+            // let name_to_tools = pin!(name_to_tools);
+
+                loop {
+                let agent_event = self
+                    .agent
+                    .plan(&steps, input_variables.clone())
+                    .await
+                    .map_err(|e| ChainError::AgentError(format!("Error in agent planning: {}", e)))?;
+                match agent_event {
+                    AgentEvent::Action(actions) => {
+                        for action in actions {
+                            log::debug!("Action: {:?}", action.tool_input);
+                            let tool = name_to_tools
+                                .get(&action.tool)
+                                .ok_or_else(|| {
+                                    AgentError::ToolError(format!("Tool {} not found", action.tool))
+                                })
+                                .map_err(|e| ChainError::AgentError(e.to_string()))?;
+
+                            let observation_result = tool.call(&action.tool_input).await;
+
+                            // let observation = match observation_result.map_err(|e| Box::into_pin(e)) {
+                            //     Ok(result) => result,
+                            //     Err(err) => {
+                            //         // let err = pin!(err);
+                            //         log::info!(
+                            //             "The tool return the following error: {}",
+                            //             err.to_string()
+                            //         );
+                            //         if self.break_if_error {
+                            //             let err_string = err.to_string();
+                            //             let intermed_err = AgentError::ToolError(err_string).to_string();
+                            //             drop(err);
+                            //             yield Err(ChainError::AgentError(
+                            //                 intermed_err,
+                            //             ));
+                            //             // yield Err(ChainError::AgentError(
+                            //             //     AgentError::ToolError(err.to_string()).to_string(),
+                            //             // ));
+                            //             return; // TODO: Don't always exit the loop on yield.
+                            //         } else {
+                            //             format!("The tool return the following error: {}", err)
+                            //         }
+                            //     }
+                            // };
+
+                            // steps.push((action, observation));
+
+                            match observation_result.map_err(|e| Box::new(e.to_string())) {
+                                Ok(result) => {
+                                    let observation = result;
+                                    steps.push((action, observation));
+                                }
+                                Err(err_str) => {
+                                    log::info!(
+                                        "The tool return the following error: {}",
+                                        err_str
+                                    );
+                                    if self.break_if_error {
+                                        let intermed_err = AgentError::ToolError(*err_str).to_string();
+                                        yield Err(ChainError::AgentError(
+                                            intermed_err,
+                                        ));
+                                        return; // TODO: Don't always exit the loop on yield.
+                                    } else {
+                                        let observation = format!("The tool return the following error: {}", err_str);
+                                        steps.push((action, observation));
+                                    }
+                                }
+                            }
+
+                        }
+                    }
+                    AgentEvent::Finish(finish) => {
+                        if let Some(memory) = &self.memory { //FIXME: This would be a problem if the lifetime of memory is not 'self_life
+                            let mut memory = memory.lock().await;
+
+                            memory.add_user_message(match &input_variables["input"] {
+                                // This avoids adding extra quotes to the user input in the history.
+                                serde_json::Value::String(s) => s,
+                                x => x, // this the json encoded value.
+                            });
+
+                            let mut tools_ai_message_seen: HashMap<String, ()> = HashMap::default();
+                            for (action, observation) in steps.clone() {
+                                let LogTools { tool_id, tools } = serde_json::from_str(&action.log)?;
+                                let tools_value: serde_json::Value = serde_json::from_str(&tools)?;
+                                if tools_ai_message_seen.insert(tools, ()).is_none() {
+                                    memory.add_message(
+                                        Message::new_ai_message("").with_tool_calls(tools_value),
+                                    );
+                                }
+                                memory.add_message(Message::new_tool_message(observation, tool_id));
+                            }
+
+                            memory.add_ai_message(&finish.output);
+                        }
+
+                        // So, we cannot access the memory here...
+
+                        // yield Ok(GenerateResult {
+                        //     generation: finish.output,
+                        //     ..Default::default()
+                        // });
+                        yield Ok(StreamData {
+                            value: Value::String(finish.output.clone()), //TODO: this might be a problem
+                            content: finish.output.clone(),
+                            tokens: None,
+                        });
+                        return;
+                    }
+                }
+
+                if let Some(max_iterations) = self.max_iterations {
+                    if steps.len() >= max_iterations as usize {
+                        // yield Ok(GenerateResult {
+                        //     generation: "Max iterations reached".to_string(),
+                        //     ..Default::default()
+                        // });
+                        yield Ok(StreamData {
+                            value: Value::String("Max iterations reached".to_string()), //TODO: this might be a problem
+                            content: "Max iterations reached".to_string(),
+                            tokens: None,
+                        });
+                        return;
+                    }
+                }
+            }
+        };
+
+        return Ok(Box::pin(main_stream));
     }
 }

--- a/src/chain/chain_trait.rs
+++ b/src/chain/chain_trait.rs
@@ -171,10 +171,10 @@ pub trait Chain: Sync + Send {
     /// # };
     /// ```
     ///
-    async fn stream(
-        &self,
+    async fn stream<'self_life>(
+        &'self_life self,
         _input_variables: PromptArgs,
-    ) -> Result<Pin<Box<dyn Stream<Item = Result<StreamData, ChainError>> + Send>>, ChainError>
+    ) -> Result<Pin<Box<dyn Stream<Item = Result<StreamData, ChainError>> + Send + 'self_life>>, ChainError>
     {
         log::warn!("stream not implemented for this chain");
         unimplemented!()

--- a/src/chain/conversational/mod.rs
+++ b/src/chain/conversational/mod.rs
@@ -79,10 +79,10 @@ impl Chain for ConversationalChain {
         Ok(result)
     }
 
-    async fn stream(
-        &self,
+    async fn stream<'self_life>(
+        &'self_life self,
         input_variables: PromptArgs,
-    ) -> Result<Pin<Box<dyn Stream<Item = Result<StreamData, ChainError>> + Send>>, ChainError>
+    ) -> Result<Pin<Box<dyn Stream<Item = Result<StreamData, ChainError>> + Send + 'self_life>>, ChainError>
     {
         let input_variable = &input_variables
             .get(&self.input_key)

--- a/src/chain/conversational_retrieval_qa/conversational_retrieval_qa.rs
+++ b/src/chain/conversational_retrieval_qa/conversational_retrieval_qa.rs
@@ -148,10 +148,10 @@ impl Chain for ConversationalRetrieverChain {
         Ok(result)
     }
 
-    async fn stream(
-        &self,
+    async fn stream<'self_life>(
+        &'self_life self,
         input_variables: PromptArgs,
-    ) -> Result<Pin<Box<dyn Stream<Item = Result<StreamData, ChainError>> + Send>>, ChainError>
+    ) -> Result<Pin<Box<dyn Stream<Item = Result<StreamData, ChainError>> + Send + 'self_life>>, ChainError>
     {
         let input_variable = &input_variables
             .get(&self.input_key)

--- a/src/chain/llm_chain.rs
+++ b/src/chain/llm_chain.rs
@@ -120,10 +120,10 @@ impl Chain for LLMChain {
         Ok(output)
     }
 
-    async fn stream(
-        &self,
+    async fn stream<'self_life>(
+        &'self_life self,
         input_variables: PromptArgs,
-    ) -> Result<Pin<Box<dyn Stream<Item = Result<StreamData, ChainError>> + Send>>, ChainError>
+    ) -> Result<Pin<Box<dyn Stream<Item = Result<StreamData, ChainError>> + Send + 'self_life>>, ChainError>
     {
         let prompt = self.prompt.format_prompt(input_variables.clone())?;
         log::debug!("Prompt: {:?}", prompt);

--- a/src/chain/question_answering.rs
+++ b/src/chain/question_answering.rs
@@ -81,10 +81,10 @@ impl Chain for CondenseQuestionGeneratorChain {
         self.chain.call(input_variables).await
     }
 
-    async fn stream(
-        &self,
+    async fn stream<'self_life>(
+        &'self_life self,
         input_variables: PromptArgs,
-    ) -> Result<Pin<Box<dyn Stream<Item = Result<StreamData, ChainError>> + Send>>, ChainError>
+    ) -> Result<Pin<Box<dyn Stream<Item = Result<StreamData, ChainError>> + Send + 'self_life>>, ChainError>
     {
         self.chain.stream(input_variables).await
     }

--- a/src/chain/sql_datbase/chain.rs
+++ b/src/chain/sql_datbase/chain.rs
@@ -188,10 +188,10 @@ impl Chain for SQLDatabaseChain {
         Ok(result.generation)
     }
 
-    async fn stream(
-        &self,
+    async fn stream<'self_life>(
+        &'self_life self,
         input_variables: PromptArgs,
-    ) -> Result<Pin<Box<dyn Stream<Item = Result<StreamData, ChainError>> + Send>>, ChainError>
+    ) -> Result<Pin<Box<dyn Stream<Item = Result<StreamData, ChainError>> + Send + 'self_life>>, ChainError>
     {
         let (llm_inputs, _) = self.call_builder_chains(&input_variables).await?;
 

--- a/src/chain/stuff_documents/chain.rs
+++ b/src/chain/stuff_documents/chain.rs
@@ -137,10 +137,10 @@ impl Chain for StuffDocument {
         self.llm_chain.call(input_values).await
     }
 
-    async fn stream(
-        &self,
+    async fn stream<'self_life>(
+        &'self_life self,
         input_variables: PromptArgs,
-    ) -> Result<Pin<Box<dyn Stream<Item = Result<StreamData, ChainError>> + Send>>, ChainError>
+    ) -> Result<Pin<Box<dyn Stream<Item = Result<StreamData, ChainError>> + Send + 'self_life>>, ChainError>
     {
         let docs = input_variables
             .get(&self.input_key)

--- a/src/llm/ollama/openai.rs
+++ b/src/llm/ollama/openai.rs
@@ -77,7 +77,7 @@ mod tests {
     use tokio_stream::StreamExt;
 
     #[tokio::test]
-    #[ignore]
+    // #[ignore]
     async fn test_ollama_openai() {
         let ollama = OpenAI::new(OllamaConfig::default()).with_model("llama2");
         let response = ollama.invoke("hola").await.unwrap();
@@ -85,7 +85,7 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore]
+    // #[ignore]
     async fn test_ollama_openai_stream() {
         let ollama = OpenAI::new(OllamaConfig::default()).with_model("phi3");
 


### PR DESCRIPTION
Because I need it for a personal project of mine, I implemented a half-baked streaming implementation for agents. 

Currently, no intermeadiate steps are streamed and only the final output is output, but it's a step in the right direction.

It's not very tested, I'm afraid.
I also had to slightly change the signature for the `stream` method of the `Chain` trait to accomodate the changes in lifetimes; a stream may now no longer outlive the Chain it is called on because else its memory would be a nightmare to handle.

Starts work on #1.
Starts work on #237.

I'll maybe work on the intermeadiate steps tomorrow. 
Feedback and requests welcome.