### PR TITLE
fix: inconsistent tool name handling in agent executor

### DIFF
--- a/src/agent/executor.rs
+++ b/src/agent/executor.rs
@@ -97,7 +97,7 @@ where
                     for action in actions {
                         log::debug!("Action: {:?}", action.tool_input);
                         let tool = name_to_tools
-                            .get(&action.tool)
+                            .get(&action.tool.trim().replace(" ", "_"))
                             .ok_or_else(|| {
                                 AgentError::ToolError(format!("Tool {} not found", action.tool))
                             })


### PR DESCRIPTION
The HashMap created by `AgentExecutor::get_name_to_tools()` uses `tool.name().trim().replace(" ", "_")` for keys
https://github.com/Abraxas-365/langchain-rust/blob/60c71258d8a40c278f2867f6b4d3871265f6e638/src/agent/executor.rs#L59-L66

But just `tool.name()` is used here, which means any tools that have spaces in their names will not be found.
https://github.com/Abraxas-365/langchain-rust/blob/60c71258d8a40c278f2867f6b4d3871265f6e638/src/agent/executor.rs#L99-L104

This pull request simply adds `.trim().replace(" ", "_")` for the `.get()` call

Accidentally deleted #292, same pull request