### PR TITLE
Make `add_document`'s `opt` argument be a Rust Option

### DIFF
--- a/examples/vector_store_surrealdb/src/main.rs
+++ b/examples/vector_store_surrealdb/src/main.rs
@@ -65,7 +65,7 @@ async fn main() {
     let doc4 = Document::new("Capital of France is Paris.");
 
     store
-        .add_documents(&vec![doc1, doc2, doc3, doc4], &VecStoreOptions::default())
+        .add_documents(&vec![doc1, doc2, doc3, doc4], None)
         .await
         .unwrap();
 

--- a/src/vectorstore/opensearch/opensearch.rs
+++ b/src/vectorstore/opensearch/opensearch.rs
@@ -104,10 +104,15 @@ impl VectorStore for Store {
     async fn add_documents(
         &self,
         docs: &[Document],
-        opt: &Self::Options,
+        opt: Option<&Self::Options>,
     ) -> Result<Vec<String>, Box<dyn Error>> {
+        let embedder = if let Some(options) = opt {
+            options.embedder.as_ref().unwrap_or(&self.embedder)
+        } else {
+            &self.embedder
+        };
+
         let texts: Vec<String> = docs.iter().map(|d| d.page_content.clone()).collect();
-        let embedder = opt.embedder.as_ref().unwrap_or(&self.embedder);
         let vectors = embedder.embed_documents(&texts).await?;
 
         if vectors.len() != docs.len() {

--- a/src/vectorstore/qdrant/qdrant.rs
+++ b/src/vectorstore/qdrant/qdrant.rs
@@ -38,9 +38,14 @@ impl VectorStore for Store {
     async fn add_documents(
         &self,
         docs: &[Document],
-        opt: &QdrantOptions,
+        opt: Option<&QdrantOptions>,
     ) -> Result<Vec<String>, Box<dyn Error>> {
-        let embedder = opt.embedder.as_ref().unwrap_or(&self.embedder);
+        let embedder = if let Some(options) = opt {
+            options.embedder.as_ref().unwrap_or(&self.embedder)
+        } else {
+            &self.embedder
+        };
+
         let texts: Vec<String> = docs.iter().map(|d| d.page_content.clone()).collect();
 
         let ids = docs.iter().map(|_| Uuid::new_v4().to_string());

--- a/src/vectorstore/sqlite_vec/sqlite_vec.rs
+++ b/src/vectorstore/sqlite_vec/sqlite_vec.rs
@@ -92,11 +92,15 @@ impl VectorStore for Store {
     async fn add_documents(
         &self,
         docs: &[Document],
-        opt: &Self::Options,
+        opt: Option<&Self::Options>,
     ) -> Result<Vec<String>, Box<dyn Error>> {
-        let texts: Vec<String> = docs.iter().map(|d| d.page_content.clone()).collect();
+        let embedder = if let Some(options) = opt {
+            options.embedder.as_ref().unwrap_or(&self.embedder)
+        } else {
+            &self.embedder
+        };
 
-        let embedder = opt.embedder.as_ref().unwrap_or(&self.embedder);
+        let texts: Vec<String> = docs.iter().map(|d| d.page_content.clone()).collect();
 
         let vectors = embedder.embed_documents(&texts).await?;
         if vectors.len() != docs.len() {

--- a/src/vectorstore/sqlite_vss/sqlite_vss.rs
+++ b/src/vectorstore/sqlite_vss/sqlite_vss.rs
@@ -80,11 +80,15 @@ impl VectorStore for Store {
     async fn add_documents(
         &self,
         docs: &[Document],
-        opt: &Self::Options,
+        opt: Option<&Self::Options>,
     ) -> Result<Vec<String>, Box<dyn Error>> {
-        let texts: Vec<String> = docs.iter().map(|d| d.page_content.clone()).collect();
+         let embedder = if let Some(options) = opt {
+            options.embedder.as_ref().unwrap_or(&self.embedder)
+        } else {
+            &self.embedder
+        };
 
-        let embedder = opt.embedder.as_ref().unwrap_or(&self.embedder);
+        let texts: Vec<String> = docs.iter().map(|d| d.page_content.clone()).collect();
 
         let vectors = embedder.embed_documents(&texts).await?;
         if vectors.len() != docs.len() {

--- a/src/vectorstore/vectorstore.rs
+++ b/src/vectorstore/vectorstore.rs
@@ -15,7 +15,7 @@ pub trait VectorStore: Send + Sync {
     async fn add_documents(
         &self,
         docs: &[Document],
-        opt: &Self::Options,
+        opt: Option<&Self::Options>,
     ) -> Result<Vec<String>, Box<dyn Error>>;
 
     async fn similarity_search(


### PR DESCRIPTION
Change `VectorStore`'s `add_document` function to take an `Option<&Self::Options>` instead of `&Self::Options`. This makes it more obvious to the user of the lib that you aren't going to accidentally override a previously set option by throwing a default object in.