### PR TITLE
Modify SurrealDB example a tad

### DIFF
--- a/examples/vector_store_surrealdb/src/main.rs
+++ b/examples/vector_store_surrealdb/src/main.rs
@@ -1,14 +1,16 @@
-// To run this example execute: `cargo run` in the folder.
+// To run this example execute: `cargo run` in the folder. Be sure to have an OpenAPI key
+// set to the OPENAI_API_KEY env var
 
+use anyhow::Error;
 use langchain_rust::{
     embedding::openai::openai_embedder::OpenAiEmbedder,
     schemas::Document,
-    vectorstore::{surrealdb::StoreBuilder, VecStoreOptions, VectorStore},
+    vectorstore::{VecStoreOptions, VectorStore, surrealdb::StoreBuilder},
 };
 use std::io::Write;
 
 #[tokio::main]
-async fn main() {
+async fn main() -> Result<(), Error> {
     // Initialize Embedder
     let embedder = OpenAiEmbedder::default();
 
@@ -17,28 +19,20 @@ async fn main() {
     let surrealdb_config = surrealdb::opt::Config::new()
         .set_strict(true)
         .capabilities(surrealdb::opt::capabilities::Capabilities::all());
-    //  Uncomment the following lines to enable authentication
+    //  Uncomment the following lines to authenticate if necessary
     //  .user(surrealdb::opt::auth::Root {
     //      username: "root".into(),
     //      password: "root".into(),
     //  });
 
-    let db = surrealdb::engine::any::connect((database_url, surrealdb_config))
-        .await
-        .unwrap();
-    db.query("DEFINE NAMESPACE test;")
-        .await
-        .unwrap()
-        .check()
-        .unwrap();
+    let db = surrealdb::engine::any::connect((database_url, surrealdb_config)).await?;
+    db.query("DEFINE NAMESPACE test;").await.unwrap().check()?;
     db.query("USE NAMESPACE test; DEFINE DATABASE test;")
-        .await
-        .unwrap()
-        .check()
-        .unwrap();
+        .await?
+        .check()?;
 
-    db.use_ns("test").await.unwrap();
-    db.use_db("test").await.unwrap();
+    db.use_ns("test").await?;
+    db.use_db("test").await?;
 
     // Initialize the Sqlite Vector Store
     let store = StoreBuilder::new()
@@ -57,10 +51,10 @@ async fn main() {
         "langchain-rust is a port of the langchain python library to rust and was written in 2024.",
     );
     let doc2 = Document::new(
-        "langchaingo is a port of the langchain python library to go language and was written in 2023."
+        "langchaingo is a port of the langchain python library to go language and was written in 2023.",
     );
     let doc3 = Document::new(
-        "Capital of United States of America (USA) is Washington D.C. and the capital of France is Paris."
+        "Capital of United States of America (USA) is Washington D.C. and the capital of France is Paris.",
     );
     let doc4 = Document::new("Capital of France is Paris.");
 
@@ -71,9 +65,9 @@ async fn main() {
 
     // Ask for user input
     print!("Query> ");
-    std::io::stdout().flush().unwrap();
+    std::io::stdout().flush()?;
     let mut query = String::new();
-    std::io::stdin().read_line(&mut query).unwrap();
+    std::io::stdin().read_line(&mut query)?;
 
     let results = store
         .similarity_search(
@@ -86,10 +80,11 @@ async fn main() {
 
     if results.is_empty() {
         println!("No results found.");
-        return;
+        return Ok(());
     } else {
         results.iter().for_each(|r| {
             println!("Document: {}", r.page_content);
         });
-    }
+    };
+    Ok(())
 }


### PR DESCRIPTION
Hi,

Had a look over the SurrealDB example here which works well, I thought I'd make a few slight modifications:

* Note that it will look for the OPENAI_API_KEY env var
* Specify that the .user() part isn't to enable authentication but to authenticate (requiring authentication was made the default setting in 2.0 so the --unauthenticated flag is now used to opt out as opposed to before when it needed a flag to opt in)
* I see that anyhow is in Cargo.toml so might as well use it and add some question mark operator where the compiler doesn't complain about thread safety.

Also just a heads up that the docs link in https://crates.io/crates/langchain-rust seems to be dead, should it be https://docs.rs/langchain-rust/latest/langchain_rust/ instead?