### PR TITLE
fix: set stream option to true when streaming is enabled.

### DIFF
--- a/src/llm/openai/mod.rs
+++ b/src/llm/openai/mod.rs
@@ -292,6 +292,7 @@ impl<C: Config> OpenAI<C> {
             request_builder.max_tokens(max_tokens);
         }
         if stream {
+            request_builder.stream(true);
             if let Some(include_usage) = self.options.stream_usage {
                 request_builder.stream_options(ChatCompletionStreamOptions { include_usage });
             }


### PR DESCRIPTION
fix: set stream option to true when streaming is enabled.

When missing this option, getting this error:
Error invoking LLMChain: OpenAIError(StreamError("Invalid header value: \"application/json\""))

this PR will solve issue reported here: https://github.com/Abraxas-365/langchain-rust/issues/290


