### PR TITLE
perf(memory): replace Vec with VecDeque in WindowBufferMemory

### DIFF
--- a/src/memory/window_buffer.rs
+++ b/src/memory/window_buffer.rs
@@ -1,12 +1,17 @@
+use std::collections::VecDeque;
 use std::sync::Arc;
 
 use tokio::sync::Mutex;
 
 use crate::schemas::{memory::BaseMemory, messages::Message};
 
+/// A sliding-window conversation memory that retains the last `window_size` messages.
+///
+/// Internally uses a [`VecDeque`] so that evicting the oldest message on overflow
+/// is O(1) rather than the O(n) `Vec::remove(0)` it replaces.
 pub struct WindowBufferMemory {
     window_size: usize,
-    messages: Vec<Message>,
+    messages: VecDeque<Message>,
 }
 
 impl Default for WindowBufferMemory {
@@ -18,7 +23,7 @@ impl Default for WindowBufferMemory {
 impl WindowBufferMemory {
     pub fn new(window_size: usize) -> Self {
         Self {
-            messages: Vec::new(),
+            messages: VecDeque::new(),
             window_size,
         }
     }
@@ -38,13 +43,13 @@ impl Into<Arc<Mutex<dyn BaseMemory>>> for WindowBufferMemory {
 
 impl BaseMemory for WindowBufferMemory {
     fn messages(&self) -> Vec<Message> {
-        self.messages.clone()
+        self.messages.iter().cloned().collect()
     }
     fn add_message(&mut self, message: Message) {
-        if self.messages.len() >= self.window_size {
-            self.messages.remove(0);
+        if self.window_size > 0 && self.messages.len() >= self.window_size {
+            self.messages.pop_front();
         }
-        self.messages.push(message);
+        self.messages.push_back(message);
     }
     fn clear(&mut self) {
         self.messages.clear();


### PR DESCRIPTION
## Problem

`WindowBufferMemory::add_message` uses `Vec<Message>` as its backing store and calls `self.messages.remove(0)` to evict the oldest message when the window is full.

`Vec::remove(0)` is **O(n)** — it must shift every remaining element one position to the left.  For a window of size `w`, each insertion when full costs O(w) time.  In a long-running agent loop this adds up: 1 000 insertions into a window of 100 = 100 000 element moves.

## Fix

Replace `Vec<Message>` with `VecDeque<Message>`:

- `pop_front()` evicts the oldest message in **O(1)**
- `push_back()` appends the new message in amortised **O(1)**  
- `messages()` collects via an iterator — same output, same API

Also adds a `window_size == 0` guard so that setting an unbounded window does not accidentally evict on the very first call.

## Diff summary

```diff
-    messages: Vec<Message>,
+    messages: VecDeque<Message>,

-    fn add_message(&mut self, message: Message) {
-        if self.messages.len() >= self.window_size {
-            self.messages.remove(0);      // O(n)
-        }
-        self.messages.push(message);
+    fn add_message(&mut self, message: Message) {
+        if self.window_size > 0 && self.messages.len() >= self.window_size {
+            self.messages.pop_front();    // O(1)
+        }
+        self.messages.push_back(message);
```

No public API change — `BaseMemory` trait methods are identical.