### PR TITLE
feat: add MiniMax as first-class LLM provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ This is the Rust language implementation of [LangChain](https://github.com/langc
   - [x] [Azure OpenAi](https://github.com/Abraxas-365/langchain-rust/blob/main/examples/llm_azure_open_ai.rs)
   - [x] [Ollama](https://github.com/Abraxas-365/langchain-rust/blob/main/examples/llm_ollama.rs)
   - [x] [Anthropic Claude](https://github.com/Abraxas-365/langchain-rust/blob/main/examples/llm_anthropic_claude.rs)
+  - [x] [MiniMax](https://github.com/Abraxas-365/langchain-rust/blob/main/examples/llm_minimax.rs)
 
 - Embeddings
 

--- a/examples/llm_minimax.rs
+++ b/examples/llm_minimax.rs
@@ -1,0 +1,60 @@
+use langchain_rust::{
+    chain::{chain_trait::Chain, llm_chain::LLMChainBuilder},
+    language_models::options::CallOptions,
+    llm::{MiniMax, MiniMaxModel},
+    prompt::{PromptTemplate, TemplateFormat},
+    prompt_args,
+};
+use std::env;
+
+#[tokio::main]
+async fn main() {
+    // Get API key from environment variable
+    let api_key =
+        env::var("MINIMAX_API_KEY").expect("MINIMAX_API_KEY environment variable must be set");
+
+    // Setup the MiniMax client with desired model and parameters
+    let minimax = MiniMax::new()
+        .with_api_key(api_key)
+        .with_model(MiniMaxModel::MiniMaxM27.to_string())
+        .with_options(
+            CallOptions::default()
+                .with_max_tokens(800)
+                .with_temperature(0.7),
+        );
+
+    // Create a prompt template
+    let template = r#"
+    You are a helpful assistant that provides detailed information.
+
+    User question: {question}
+
+    Please provide a comprehensive answer:
+    "#;
+
+    let prompt = PromptTemplate::new(
+        template.to_owned(),
+        vec!["question".to_owned()],
+        TemplateFormat::FString,
+    );
+
+    // Create an LLMChain using the builder pattern
+    let chain = LLMChainBuilder::new()
+        .prompt(prompt)
+        .llm(minimax)
+        .build()
+        .unwrap();
+
+    // Execute the chain with a question
+    let inputs = prompt_args! {
+        "question" => "Explain the importance of quantum computing and its potential applications."
+    };
+
+    let result = chain.call(inputs).await.unwrap();
+
+    println!(
+        "Question: Explain the importance of quantum computing and its potential applications."
+    );
+    println!("\nMiniMax's response:");
+    println!("{}", result.generation);
+}

--- a/src/language_models/error.rs
+++ b/src/language_models/error.rs
@@ -6,7 +6,7 @@ use serde_json::Error as SerdeJsonError;
 use thiserror::Error;
 use tokio::time::error::Elapsed;
 
-use crate::llm::{AnthropicError, DeepseekError, QwenError};
+use crate::llm::{AnthropicError, DeepseekError, MiniMaxError, QwenError};
 
 #[derive(Error, Debug)]
 pub enum LLMError {
@@ -21,6 +21,9 @@ pub enum LLMError {
 
     #[error("Deepseek error: {0}")]
     DeepseekError(#[from] DeepseekError),
+
+    #[error("MiniMax error: {0}")]
+    MiniMaxError(#[from] MiniMaxError),
 
     #[cfg(feature = "ollama")]
     #[error("Ollama error: {0}")]

--- a/src/llm/minimax/client.rs
+++ b/src/llm/minimax/client.rs
@@ -1,0 +1,627 @@
+use crate::{
+    language_models::{llm::LLM, options::CallOptions, GenerateResult, LLMError, TokenUsage},
+    llm::MiniMaxError,
+    schemas::{Message, StreamData},
+};
+use async_trait::async_trait;
+use futures::{Stream, StreamExt};
+use reqwest::Client;
+use serde_json::Value;
+use std::{pin::Pin, str};
+
+use super::models::{ApiResponse, MiniMaxMessage, Payload, ResponseFormat};
+
+pub enum MiniMaxModel {
+    MiniMaxM27,
+    MiniMaxM27Highspeed,
+    MiniMaxM25,
+    MiniMaxM25Highspeed,
+}
+
+impl ToString for MiniMaxModel {
+    fn to_string(&self) -> String {
+        match self {
+            MiniMaxModel::MiniMaxM27 => "MiniMax-M2.7".to_string(),
+            MiniMaxModel::MiniMaxM27Highspeed => "MiniMax-M2.7-highspeed".to_string(),
+            MiniMaxModel::MiniMaxM25 => "MiniMax-M2.5".to_string(),
+            MiniMaxModel::MiniMaxM25Highspeed => "MiniMax-M2.5-highspeed".to_string(),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct MiniMax {
+    model: String,
+    options: CallOptions,
+    api_key: String,
+    base_url: String,
+    json_mode: bool,
+}
+
+impl Default for MiniMax {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl MiniMax {
+    pub fn new() -> Self {
+        Self {
+            model: MiniMaxModel::MiniMaxM27.to_string(),
+            options: CallOptions::default(),
+            api_key: std::env::var("MINIMAX_API_KEY").unwrap_or_default(),
+            base_url: "https://api.minimax.io".to_string(),
+            json_mode: false,
+        }
+    }
+
+    pub fn with_model<S: Into<String>>(mut self, model: S) -> Self {
+        self.model = model.into();
+        self
+    }
+
+    pub fn with_options(mut self, options: CallOptions) -> Self {
+        self.options = options;
+        self
+    }
+
+    pub fn with_api_key<S: Into<String>>(mut self, api_key: S) -> Self {
+        self.api_key = api_key.into();
+        self
+    }
+
+    pub fn with_base_url<S: Into<String>>(mut self, base_url: S) -> Self {
+        self.base_url = base_url.into();
+        self
+    }
+
+    pub fn with_json_mode(mut self, json_mode: bool) -> Self {
+        self.json_mode = json_mode;
+        self
+    }
+
+    /// Clamp temperature to MiniMax's accepted range [0.0, 1.0].
+    fn clamp_temperature(temp: Option<f32>) -> Option<f32> {
+        temp.map(|t| t.clamp(0.0, 1.0))
+    }
+
+    async fn generate(&self, messages: &[Message]) -> Result<GenerateResult, LLMError> {
+        let client = Client::new();
+        let is_stream = self.options.streaming_func.is_some();
+
+        let payload = self.build_payload(messages, is_stream);
+        let res = client
+            .post(&format!("{}/v1/chat/completions", self.base_url))
+            .header("Authorization", format!("Bearer {}", self.api_key))
+            .header("Content-Type", "application/json")
+            .json(&payload)
+            .send()
+            .await?;
+
+        let status = res.status().as_u16();
+
+        let res = match status {
+            400 => Err(LLMError::MiniMaxError(MiniMaxError::InvalidFormatError(
+                "Invalid request format".to_string(),
+            ))),
+            401 => Err(LLMError::MiniMaxError(MiniMaxError::AuthenticationError(
+                "Invalid API Key".to_string(),
+            ))),
+            402 => Err(LLMError::MiniMaxError(
+                MiniMaxError::InsufficientBalanceError("Insufficient balance".to_string()),
+            )),
+            422 => Err(LLMError::MiniMaxError(
+                MiniMaxError::InvalidParametersError("Invalid parameters".to_string()),
+            )),
+            429 => Err(LLMError::MiniMaxError(MiniMaxError::RateLimitError(
+                "Rate limit reached".to_string(),
+            ))),
+            500 => Err(LLMError::MiniMaxError(MiniMaxError::ServerError(
+                "Server error".to_string(),
+            ))),
+            503 => Err(LLMError::MiniMaxError(
+                MiniMaxError::ServerOverloadedError("Server overloaded".to_string()),
+            )),
+            _ => Ok(res.json::<ApiResponse>().await?),
+        }?;
+
+        let choice = res.choices.first();
+
+        let generation = choice
+            .map(|c| Self::strip_think_tags(&c.message.content))
+            .unwrap_or_default();
+
+        let tokens = Some(TokenUsage {
+            prompt_tokens: res.usage.prompt_tokens,
+            completion_tokens: res.usage.completion_tokens,
+            total_tokens: res.usage.total_tokens,
+        });
+
+        Ok(GenerateResult { tokens, generation })
+    }
+
+    fn build_payload(&self, messages: &[Message], stream: bool) -> Payload {
+        let mut response_format = None;
+        if self.json_mode {
+            response_format = Some(ResponseFormat {
+                format_type: "json_object".to_string(),
+            });
+        }
+
+        let mut payload = Payload {
+            model: self.model.clone(),
+            messages: messages
+                .iter()
+                .map(MiniMaxMessage::from_message)
+                .collect::<Vec<_>>(),
+            max_tokens: self.options.max_tokens,
+            stream: None,
+            temperature: Self::clamp_temperature(self.options.temperature),
+            top_p: self.options.top_p,
+            frequency_penalty: None,
+            presence_penalty: None,
+            stop: self.options.stop_words.clone(),
+            response_format,
+        };
+
+        if stream {
+            payload.stream = Some(true);
+        }
+
+        if let Some(fp) = self.options.frequency_penalty {
+            if fp >= -2.0 && fp <= 2.0 {
+                payload.frequency_penalty = Some(fp);
+            }
+        }
+
+        if let Some(pp) = self.options.presence_penalty {
+            if pp >= -2.0 && pp <= 2.0 {
+                payload.presence_penalty = Some(pp);
+            }
+        }
+
+        payload
+    }
+
+    /// Strip `<think>...</think>` tags from MiniMax M2.5+ reasoning output.
+    fn strip_think_tags(content: &str) -> String {
+        let mut result = content.to_string();
+        while let Some(start) = result.find("<think>") {
+            if let Some(end) = result.find("</think>") {
+                result = format!("{}{}", &result[..start], &result[end + 8..]);
+            } else {
+                break;
+            }
+        }
+        result.trim().to_string()
+    }
+
+    fn parse_sse_chunk(chunk: &[u8]) -> Result<Vec<Value>, LLMError> {
+        let text = str::from_utf8(chunk).map_err(|e| LLMError::ParsingError(e.to_string()))?;
+        let mut values = Vec::new();
+
+        for line in text.lines() {
+            if line.starts_with("data: ") {
+                let data = &line[6..];
+                if data == "[DONE]" {
+                    continue;
+                }
+                let value: Value = serde_json::from_str(data).map_err(|e| {
+                    LLMError::ParsingError(format!("Failed to parse SSE data: {}", e))
+                })?;
+                values.push(value);
+            }
+        }
+
+        Ok(values)
+    }
+}
+
+#[async_trait]
+impl LLM for MiniMax {
+    async fn generate(&self, messages: &[Message]) -> Result<GenerateResult, LLMError> {
+        match &self.options.streaming_func {
+            Some(func) => {
+                let mut complete_response = String::new();
+                let mut stream = self.stream(messages).await?;
+                while let Some(data) = stream.next().await {
+                    match data {
+                        Ok(value) => {
+                            let mut func = func.lock().await;
+                            complete_response.push_str(&value.content);
+                            let _ = func(value.content).await;
+                        }
+                        Err(e) => return Err(e),
+                    }
+                }
+                let mut generate_result = GenerateResult::default();
+                generate_result.generation = complete_response;
+                Ok(generate_result)
+            }
+            None => self.generate(messages).await,
+        }
+    }
+
+    async fn stream(
+        &self,
+        messages: &[Message],
+    ) -> Result<Pin<Box<dyn Stream<Item = Result<StreamData, LLMError>> + Send>>, LLMError> {
+        let client = Client::new();
+        let payload = self.build_payload(messages, true);
+        let request = client
+            .post(&format!("{}/v1/chat/completions", self.base_url))
+            .header("Authorization", format!("Bearer {}", self.api_key))
+            .header("Content-Type", "application/json")
+            .json(&payload)
+            .build()?;
+
+        let stream = client.execute(request).await?;
+        let stream = stream.bytes_stream();
+
+        let processed_stream = stream
+            .then(move |result| async move {
+                match result {
+                    Ok(bytes) => {
+                        let chunks = Self::parse_sse_chunk(&bytes)?;
+
+                        for chunk in chunks {
+                            if let Some(choices) =
+                                chunk.get("choices").and_then(|c| c.as_array())
+                            {
+                                if let Some(choice) = choices.first() {
+                                    if let Some(delta) = choice.get("delta") {
+                                        if let Some(content) =
+                                            delta.get("content").and_then(|c| c.as_str())
+                                        {
+                                            if !content.is_empty() {
+                                                let usage =
+                                                    if let Some(usage) = chunk.get("usage") {
+                                                        Some(TokenUsage {
+                                                            prompt_tokens: usage
+                                                                .get("prompt_tokens")
+                                                                .and_then(|t| t.as_u64())
+                                                                .unwrap_or(0)
+                                                                as u32,
+                                                            completion_tokens: usage
+                                                                .get("completion_tokens")
+                                                                .and_then(|t| t.as_u64())
+                                                                .unwrap_or(0)
+                                                                as u32,
+                                                            total_tokens: usage
+                                                                .get("total_tokens")
+                                                                .and_then(|t| t.as_u64())
+                                                                .unwrap_or(0)
+                                                                as u32,
+                                                        })
+                                                    } else {
+                                                        None
+                                                    };
+
+                                                return Ok(StreamData::new(
+                                                    chunk.clone(),
+                                                    usage,
+                                                    content,
+                                                ));
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+
+                        Ok(StreamData::new(Value::Null, None, ""))
+                    }
+                    Err(e) => Err(LLMError::OtherError(e.to_string())),
+                }
+            })
+            .filter_map(|result| async move {
+                match result {
+                    Ok(data) if !data.content.is_empty() => Some(Ok(data)),
+                    Ok(_) => None,
+                    Err(e) => Some(Err(e)),
+                }
+            });
+
+        Ok(Box::pin(processed_stream))
+    }
+
+    fn add_options(&mut self, options: CallOptions) {
+        self.options = options;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::schemas::{Message, MessageType};
+
+    #[test]
+    fn test_minimax_model_names() {
+        assert_eq!(MiniMaxModel::MiniMaxM27.to_string(), "MiniMax-M2.7");
+        assert_eq!(
+            MiniMaxModel::MiniMaxM27Highspeed.to_string(),
+            "MiniMax-M2.7-highspeed"
+        );
+        assert_eq!(MiniMaxModel::MiniMaxM25.to_string(), "MiniMax-M2.5");
+        assert_eq!(
+            MiniMaxModel::MiniMaxM25Highspeed.to_string(),
+            "MiniMax-M2.5-highspeed"
+        );
+    }
+
+    #[test]
+    fn test_minimax_default() {
+        let client = MiniMax::new();
+        assert_eq!(client.model, "MiniMax-M2.7");
+        assert_eq!(client.base_url, "https://api.minimax.io");
+        assert!(!client.json_mode);
+    }
+
+    #[test]
+    fn test_minimax_builder() {
+        let client = MiniMax::new()
+            .with_model("MiniMax-M2.5")
+            .with_api_key("test-key")
+            .with_base_url("https://custom.api.com")
+            .with_json_mode(true);
+
+        assert_eq!(client.model, "MiniMax-M2.5");
+        assert_eq!(client.api_key, "test-key");
+        assert_eq!(client.base_url, "https://custom.api.com");
+        assert!(client.json_mode);
+    }
+
+    #[test]
+    fn test_minimax_with_options() {
+        let options = CallOptions::default()
+            .with_max_tokens(1000)
+            .with_temperature(0.7);
+        let client = MiniMax::new().with_options(options);
+        assert_eq!(client.options.max_tokens, Some(1000));
+        assert_eq!(client.options.temperature, Some(0.7));
+    }
+
+    #[test]
+    fn test_clamp_temperature() {
+        assert_eq!(MiniMax::clamp_temperature(Some(0.5)), Some(0.5));
+        assert_eq!(MiniMax::clamp_temperature(Some(1.5)), Some(1.0));
+        assert_eq!(MiniMax::clamp_temperature(Some(-0.5)), Some(0.0));
+        assert_eq!(MiniMax::clamp_temperature(None), None);
+    }
+
+    #[test]
+    fn test_strip_think_tags() {
+        assert_eq!(
+            MiniMax::strip_think_tags("<think>reasoning</think>Answer here"),
+            "Answer here"
+        );
+        assert_eq!(MiniMax::strip_think_tags("No tags here"), "No tags here");
+        assert_eq!(
+            MiniMax::strip_think_tags("<think>step 1</think>Part 1<think>step 2</think>Part 2"),
+            "Part 1Part 2"
+        );
+    }
+
+    #[test]
+    fn test_minimax_message_from_message() {
+        let msg = Message {
+            content: "Hello".to_string(),
+            message_type: MessageType::HumanMessage,
+            id: None,
+            images: None,
+            tool_calls: None,
+        };
+        let mm_msg = MiniMaxMessage::from_message(&msg);
+        assert_eq!(mm_msg.role, "user");
+        assert_eq!(mm_msg.content, "Hello");
+
+        let msg = Message {
+            content: "System prompt".to_string(),
+            message_type: MessageType::SystemMessage,
+            id: None,
+            images: None,
+            tool_calls: None,
+        };
+        let mm_msg = MiniMaxMessage::from_message(&msg);
+        assert_eq!(mm_msg.role, "system");
+
+        let msg = Message {
+            content: "AI response".to_string(),
+            message_type: MessageType::AIMessage,
+            id: None,
+            images: None,
+            tool_calls: None,
+        };
+        let mm_msg = MiniMaxMessage::from_message(&msg);
+        assert_eq!(mm_msg.role, "assistant");
+
+        let msg = Message {
+            content: "Tool output".to_string(),
+            message_type: MessageType::ToolMessage,
+            id: Some("tool-1".to_string()),
+            images: None,
+            tool_calls: None,
+        };
+        let mm_msg = MiniMaxMessage::from_message(&msg);
+        assert_eq!(mm_msg.role, "tool");
+    }
+
+    #[test]
+    fn test_build_payload_basic() {
+        let client = MiniMax::new().with_model("MiniMax-M2.7");
+        let messages = vec![Message {
+            content: "Hello".to_string(),
+            message_type: MessageType::HumanMessage,
+            id: None,
+            images: None,
+            tool_calls: None,
+        }];
+        let payload = client.build_payload(&messages, false);
+        assert_eq!(payload.model, "MiniMax-M2.7");
+        assert_eq!(payload.messages.len(), 1);
+        assert!(payload.stream.is_none());
+        assert!(payload.response_format.is_none());
+    }
+
+    #[test]
+    fn test_build_payload_stream() {
+        let client = MiniMax::new();
+        let messages = vec![Message {
+            content: "Hello".to_string(),
+            message_type: MessageType::HumanMessage,
+            id: None,
+            images: None,
+            tool_calls: None,
+        }];
+        let payload = client.build_payload(&messages, true);
+        assert_eq!(payload.stream, Some(true));
+    }
+
+    #[test]
+    fn test_build_payload_json_mode() {
+        let client = MiniMax::new().with_json_mode(true);
+        let messages = vec![Message {
+            content: "Hello".to_string(),
+            message_type: MessageType::HumanMessage,
+            id: None,
+            images: None,
+            tool_calls: None,
+        }];
+        let payload = client.build_payload(&messages, false);
+        assert!(payload.response_format.is_some());
+        assert_eq!(
+            payload.response_format.unwrap().format_type,
+            "json_object"
+        );
+    }
+
+    #[test]
+    fn test_build_payload_temperature_clamping() {
+        let options = CallOptions::default().with_temperature(1.5);
+        let client = MiniMax::new().with_options(options);
+        let messages = vec![Message {
+            content: "Hello".to_string(),
+            message_type: MessageType::HumanMessage,
+            id: None,
+            images: None,
+            tool_calls: None,
+        }];
+        let payload = client.build_payload(&messages, false);
+        assert_eq!(payload.temperature, Some(1.0));
+    }
+
+    #[test]
+    fn test_build_payload_with_stop_words() {
+        let options = CallOptions::default()
+            .with_stop_words(vec!["stop1".to_string(), "stop2".to_string()]);
+        let client = MiniMax::new().with_options(options);
+        let messages = vec![Message {
+            content: "Hello".to_string(),
+            message_type: MessageType::HumanMessage,
+            id: None,
+            images: None,
+            tool_calls: None,
+        }];
+        let payload = client.build_payload(&messages, false);
+        assert_eq!(
+            payload.stop,
+            Some(vec!["stop1".to_string(), "stop2".to_string()])
+        );
+    }
+
+    #[test]
+    fn test_build_payload_with_penalties() {
+        let options = CallOptions::default()
+            .with_frequency_penalty(0.5)
+            .with_presence_penalty(-0.5);
+        let client = MiniMax::new().with_options(options);
+        let messages = vec![Message {
+            content: "Hello".to_string(),
+            message_type: MessageType::HumanMessage,
+            id: None,
+            images: None,
+            tool_calls: None,
+        }];
+        let payload = client.build_payload(&messages, false);
+        assert_eq!(payload.frequency_penalty, Some(0.5));
+        assert_eq!(payload.presence_penalty, Some(-0.5));
+    }
+
+    #[test]
+    fn test_parse_sse_chunk_done() {
+        let chunk = b"data: [DONE]\n";
+        let values = MiniMax::parse_sse_chunk(chunk).unwrap();
+        assert!(values.is_empty());
+    }
+
+    #[test]
+    fn test_parse_sse_chunk_valid() {
+        let chunk = b"data: {\"choices\":[{\"delta\":{\"content\":\"hello\"}}]}\n";
+        let values = MiniMax::parse_sse_chunk(chunk).unwrap();
+        assert_eq!(values.len(), 1);
+    }
+
+    #[test]
+    fn test_parse_sse_chunk_empty_lines() {
+        let chunk = b"\n\ndata: {\"test\":true}\n\n";
+        let values = MiniMax::parse_sse_chunk(chunk).unwrap();
+        assert_eq!(values.len(), 1);
+    }
+
+    #[test]
+    fn test_minimax_model_enum() {
+        let model = MiniMaxModel::MiniMaxM27;
+        let client = MiniMax::new().with_model(model.to_string());
+        assert_eq!(client.model, "MiniMax-M2.7");
+    }
+
+    #[tokio::test]
+    #[ignore]
+    async fn test_minimax_generate() {
+        let messages = vec![Message {
+            content: "Hello".to_string(),
+            message_type: MessageType::HumanMessage,
+            id: Some("test_id".to_string()),
+            images: None,
+            tool_calls: None,
+        }];
+
+        let client = MiniMax::new();
+        let res = client.generate(&messages).await;
+        assert!(res.is_ok());
+    }
+
+    #[tokio::test]
+    #[ignore]
+    async fn test_minimax_stream() {
+        let messages = vec![Message {
+            content: "Hello".to_string(),
+            message_type: MessageType::HumanMessage,
+            id: Some("test_id".to_string()),
+            images: None,
+            tool_calls: None,
+        }];
+
+        let client = MiniMax::new();
+        let res = client.stream(&messages).await;
+        assert!(res.is_ok());
+    }
+
+    #[tokio::test]
+    #[ignore]
+    async fn test_minimax_m25_highspeed() {
+        let messages = vec![Message {
+            content: "What is 2+2?".to_string(),
+            message_type: MessageType::HumanMessage,
+            id: Some("test_id".to_string()),
+            images: None,
+            tool_calls: None,
+        }];
+
+        let client = MiniMax::new()
+            .with_model(MiniMaxModel::MiniMaxM25Highspeed.to_string());
+
+        let res = client.generate(&messages).await;
+        assert!(res.is_ok());
+    }
+}

--- a/src/llm/minimax/error.rs
+++ b/src/llm/minimax/error.rs
@@ -1,0 +1,25 @@
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum MiniMaxError {
+    #[error("MiniMax API error: Invalid Format - {0}")]
+    InvalidFormatError(String),
+
+    #[error("MiniMax API error: Authentication Failed - {0}")]
+    AuthenticationError(String),
+
+    #[error("MiniMax API error: Insufficient Balance - {0}")]
+    InsufficientBalanceError(String),
+
+    #[error("MiniMax API error: Invalid Parameters - {0}")]
+    InvalidParametersError(String),
+
+    #[error("MiniMax API error: Rate Limit Reached - {0}")]
+    RateLimitError(String),
+
+    #[error("MiniMax API error: Server Error - {0}")]
+    ServerError(String),
+
+    #[error("MiniMax API error: Server Overloaded - {0}")]
+    ServerOverloadedError(String),
+}

--- a/src/llm/minimax/mod.rs
+++ b/src/llm/minimax/mod.rs
@@ -1,0 +1,6 @@
+mod client;
+mod models;
+pub use client::*;
+
+mod error;
+pub use error::*;

--- a/src/llm/minimax/models.rs
+++ b/src/llm/minimax/models.rs
@@ -1,0 +1,81 @@
+use crate::schemas::{Message, MessageType};
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub(crate) struct MiniMaxMessage {
+    pub role: String,
+    pub content: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+}
+
+impl MiniMaxMessage {
+    pub fn new<S: Into<String>>(role: S, content: S) -> Self {
+        Self {
+            role: role.into(),
+            content: content.into(),
+            name: None,
+        }
+    }
+
+    pub fn from_message(message: &Message) -> Self {
+        match message.message_type {
+            MessageType::SystemMessage => Self::new("system", &message.content),
+            MessageType::AIMessage => Self::new("assistant", &message.content),
+            MessageType::HumanMessage => Self::new("user", &message.content),
+            MessageType::ToolMessage => Self::new("tool", &message.content),
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub(crate) struct ResponseFormat {
+    #[serde(rename = "type")]
+    pub format_type: String,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub(crate) struct Payload {
+    pub model: String,
+    pub messages: Vec<MiniMaxMessage>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_tokens: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stream: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub temperature: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub top_p: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub frequency_penalty: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub presence_penalty: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stop: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub response_format: Option<ResponseFormat>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub(crate) struct Usage {
+    pub prompt_tokens: u32,
+    pub completion_tokens: u32,
+    pub total_tokens: u32,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub(crate) struct Choice {
+    pub message: MiniMaxMessage,
+    pub finish_reason: Option<String>,
+    pub index: u32,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub(crate) struct ApiResponse {
+    pub id: String,
+    pub object: String,
+    pub created: u64,
+    pub model: String,
+    pub choices: Vec<Choice>,
+    pub usage: Usage,
+}

--- a/src/llm/mod.rs
+++ b/src/llm/mod.rs
@@ -12,3 +12,6 @@ pub use qwen::*;
 
 pub mod deepseek;
 pub use deepseek::*;
+
+pub mod minimax;
+pub use minimax::*;


### PR DESCRIPTION
## Summary

Adds [MiniMax AI](https://www.minimax.io/) as a new first-class LLM provider, following the established direct HTTP client pattern used by the Deepseek and Qwen implementations.

### Models Supported

| Model | Context Window | Description |
|-------|---------------|-------------|
| `MiniMax-M2.7` | 1M tokens | Latest flagship model |
| `MiniMax-M2.7-highspeed` | 1M tokens | Fast variant |
| `MiniMax-M2.5` | 204K tokens | Previous generation |
| `MiniMax-M2.5-highspeed` | 204K tokens | Fast variant |

### Features

- Full `LLM` trait implementation (`generate` + `stream`)
- Temperature clamping to MiniMax's accepted `[0.0, 1.0]` range
- Think-tag stripping for M2.5+ reasoning output
- JSON mode support via `response_format`
- Configurable base URL and API key (`MINIMAX_API_KEY` env var auto-detection)
- Frequency and presence penalty support
- SSE streaming with token usage tracking
- Builder pattern API consistent with other providers

### Files Changed (8 files, ~807 additions)

- `src/llm/minimax/client.rs` - MiniMax client with LLM trait impl + 17 unit tests
- `src/llm/minimax/models.rs` - Request/response models
- `src/llm/minimax/error.rs` - MiniMaxError enum
- `src/llm/minimax/mod.rs` - Module exports
- `src/language_models/error.rs` - Added MiniMaxError to LLMError
- `src/llm/mod.rs` - Registered minimax module
- `examples/llm_minimax.rs` - Usage example with LLMChain
- `README.md` - Added MiniMax to LLMs list

### Usage

```rust
use langchain_rust::llm::{MiniMax, MiniMaxModel};
use langchain_rust::language_models::options::CallOptions;

let minimax = MiniMax::new()
    .with_api_key("your-api-key")
    .with_model(MiniMaxModel::MiniMaxM27.to_string())
    .with_options(
        CallOptions::default()
            .with_max_tokens(800)
            .with_temperature(0.7),
    );
```

## Test Plan

- [x] 17 unit tests pass (cargo test --lib minimax)
- [x] 3 integration tests included (marked ignore, require MINIMAX_API_KEY)
- [x] Full project builds without errors (cargo check)
- [x] No new warnings introduced